### PR TITLE
Adding LTS as version opt for linux builds.

### DIFF
--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -78,7 +78,7 @@ task configureBuild(type: Exec) {
         "--with-version-feature=${version.major}",
         '--with-freetype=bundled',
         '--with-zlib=bundled',
-        '--with-version-opt=',
+        '--with-version-opt=LTS',
         "--with-version-string=${version.major}.${version.minor}.${version.security}",
         "--with-version-build=${version.build}",
         "--with-vendor-version-string=Corretto-${version.full}",


### PR DESCRIPTION
### Description
This PR changes the version string on future builds of Corretto11 for linux to include LTS as the version opt.

### Motivation and context
Windows and Mac versions of Corretto11 are generated with LTS in the version opt, but we missed it in the Linux build

### How has this been tested?
Generated a new build on Linux:
```
$ bin/java -version
openjdk version "11.0.2" 2019-01-15 LTS
OpenJDK Runtime Environment Corretto-11.0.2.9.1 (build 11.0.2+9-LTS)
OpenJDK 64-Bit Server VM Corretto-11.0.2.9.1 (build 11.0.2+9-LTS, mixed mode)
```

### Platform information
    Works on OS: CentOS6
    Applies to version: 11.0.2.9.1
