### PR TITLE
Fix Corretto 11 mac installer introduction message

### DIFF
--- a/installers/mac/pkg/resources/introduction.html
+++ b/installers/mac/pkg/resources/introduction.html
@@ -729,6 +729,6 @@ pre {
   }
 }
 </style><title>introduction</title></head><body><article class="markdown-body"><h3>
-<a id="user-content-amazon-corretto-8-installer" class="anchor" href="#amazon-corretto-8-installer" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Amazon Corretto 8 Installer</h3>
+<a id="user-content-amazon-corretto-11-installer" class="anchor" href="#amazon-corretto-11-installer" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Amazon Corretto 11 Installer</h3>
 <p>You will be guided through the steps necessary to install Amazon Corretto 11.</p>
 </article></body></html>


### PR DESCRIPTION
This commit fixes #10 

Fix the introduction message. The installer title should be "Amazon Corretto 11 Installer".