### PR TITLE
Fix libjli.dylib symlink error in Corretto 11 installer

### DIFF
--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -113,7 +113,7 @@ task prepareArtifacts {
         // Gradle does not preserve symlink, fix it before packaging
         exec {
             workingDir "${buildDir}/${correttoMacDir}/Contents"
-            commandLine "ln", "-sf", "../Home/jre/lib/jli/libjli.dylib", "MacOS/libjli.dylib"
+            commandLine "ln", "-sf", "../Home/lib/jli/libjli.dylib", "MacOS/libjli.dylib"
         }
     }
 }


### PR DESCRIPTION
`Contents/MacOS/libjli.dylib` in Corretto 11 points to the wrong path
causing Mac's java utility tool `/usr/libexec/java_home` unable to
detect amazon-corretto-11.jdk as a JDK package. Fix #12 