### PR TITLE
Insert name-version into base path of RPM source tarball.

### DIFF
--- a/installers/linux/al2/README.md
+++ b/installers/linux/al2/README.md
@@ -10,9 +10,7 @@ and tarball are located in `/installers/linux/al2/spec/corretto-build/distributi
 ➜ ./gradlew :installers:linux:al2:spec:build
 ➜ tree installers/linux/al2/spec/corretto-build/distributions
   installers/linux/al2/spec/corretto-build/distributions
-  ├── java-11-amazon-corretto.spec
-  └── SOURCES
-      └── amazon-corretto-source-11.0.2.7.1.tar.gz
+  └── amazon-corretto-source-11.0.2.7.1.tar.gz
 
 
 ```

--- a/installers/linux/al2/docker/Dockerfile
+++ b/installers/linux/al2/docker/Dockerfile
@@ -1,19 +1,14 @@
-FROM amazonlinux:2
-
-RUN yum install -y yum-utils rpm-build
-
-RUN cd /opt \
-    && curl --remote-name https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz \
-    && tar xf openjdk-11.0.2_linux-x64_bin.tar.gz \
-    && rm openjdk-11.0.2_linux-x64_bin.tar.gz
-
-WORKDIR rpmbuild
-
-COPY SOURCES SOURCES
-COPY java-11-amazon-corretto.spec .
-
-RUN yum-builddep -y java-11-amazon-corretto.spec
-
-ENV JAVA_HOME /opt/jdk-11.0.2
-
+FROM amazoncorretto:11
+COPY rpmbuild /rpmbuild
+RUN yum install -y yum-utils rpm-build \
+    && yum-builddep -y rpmbuild/java-11-amazon-corretto.spec
+ENV JAVA_HOME /usr/lib/jvm/java-11-amazon-corretto
 RUN cd /rpmbuild && rpmbuild --define "_topdir /rpmbuild" -ba java-11-amazon-corretto.spec
+
+FROM amazonlinux:2
+COPY --from=0 /rpmbuild/RPMS/x86_64 .
+RUN yum -y localinstall *.rpm \
+    && yum install -y man
+
+COPY post-install-test.sh .
+RUN /post-install-test.sh

--- a/installers/linux/al2/docker/build.gradle
+++ b/installers/linux/al2/docker/build.gradle
@@ -30,22 +30,36 @@ dependencies {
     compile project(path: ':installers:linux:al2:spec', configuration: 'archives')
 }
 
-task copySource(type: Copy) {
+// The Docker image is built in a directory that contains
+// the source tarball and the spec file.
+// The following two tasks create this directory structure:
+//  buildRoot
+//  ├── Dockerfile
+//  └── rpmbuild
+//      └── java-11-amazon-corretto.spec
+//      └── SOURCES
+//          └── amazon-corretto-source-11.0.2.7.1.tar.gz
+task createRpmBuildRoot(type: Copy) {
     dependsOn project.configurations.compile
-    from project.configurations.compile.singleFile
-    into buildRoot
+    from (project.configurations.compile.singleFile) {
+        into 'SOURCES'
+    }
+    from(tarTree(project.configurations.compile.singleFile)) {
+        include "**/java-11-amazon-corretto.spec"
+        eachFile { f -> f.path = f.name }
+    }
+    includeEmptyDirs = false
+    into "$buildRoot/rpmbuild"
 }
 
 task copyDockerFile(type: Copy) {
     from 'Dockerfile'
+    from 'post-install-test.sh'
     into buildRoot
 }
 
-assemble.dependsOn copySource
-assemble.dependsOn copyDockerFile
-
 task buildRpmsWithDocker(type: DockerBuildImage) {
-    dependsOn assemble
+    dependsOn copyDockerFile, createRpmBuildRoot
     inputDir = buildRoot
 }
 
@@ -64,4 +78,4 @@ task copyRpmsFromContainer(type: Exec) {
             "$buildDir/distributions"
 }
 
-build.dependsOn copyRpmsFromContainer
+build.dependsOn buildRpmsWithDocker

--- a/installers/linux/al2/docker/post-install-test.sh
+++ b/installers/linux/al2/docker/post-install-test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+tools=(
+    jaotc
+    jar
+    jarsigner
+    java
+    javac
+    javadoc
+    javap
+    jcmd
+    jconsole
+    jdb
+    jdeprscan
+    jdeps
+    jhsdb
+    jimage
+    jinfo
+    jjs
+    jlink
+    jmap
+    jmod
+    jps
+    jrunscript
+    jshell
+    jstack
+    jstat
+    jstatd
+    keytool
+    pack200
+    rmic
+    rmid
+    rmiregistry
+    serialver
+    unpack200
+)
+
+manuals=(
+    jar
+    jarsigner
+    java
+    javac
+    javadoc
+    javap
+    jcmd
+    jconsole
+    jdb
+    jdeps
+    jinfo
+    jjs
+    jmap
+    jps
+    jrunscript
+    jstack
+    jstat
+    jstatd
+    keytool
+    pack200
+    rmic
+    rmid
+    rmiregistry
+    serialver
+    unpack200
+)
+
+#
+# Test 1: Ensure that alternatives installs tools and man pages.
+#
+for b in ${tools[@]}; do
+    if [ "/usr/bin/$b" -ef "/usr/lib/jvm/java-11-amazon-corretto.x86_64/bin/$b" ]; then
+        echo "$b - OK"
+    else
+        echo "$b - Error. Not on path."
+        exit
+    fi
+done
+
+for m in ${manuals[@]}; do
+    if [ "$(man -w $m)" -ef "/usr/lib/jvm/java-11-amazon-corretto.x86_64/man/man1/$m.1" ]; then
+        echo "$m - OK"
+    else
+        echo "$m - Error. $m not installed."
+        exit
+    fi
+done
+
+#
+# Test 2: Remove the RPM and ensure that tools and man pages are removed.
+#
+yum remove -y java-11-amazon-corretto-headless
+
+for b in ${tools[@]}; do
+    if [ ! -f "/usr/bin/$b" ]; then
+        echo "$b - OK"
+    else
+        echo "$b - Error. $b still installed."
+        exit
+    fi
+done
+
+for m in ${manuals[@]}; do
+    if [ ! -f "/usr/share/man/man1/$m.1" ]; then
+        echo "$m - OK"
+    else
+        echo "$m - Error. $m still installed."
+        exit
+    fi
+done

--- a/installers/linux/al2/spec/build.gradle
+++ b/installers/linux/al2/spec/build.gradle
@@ -25,16 +25,13 @@ dependencies {
     compile project(path: ':openjdksrc', configuration: 'archives')
 }
 
-task copySourceTar(type: Copy) {
-    dependsOn project.configurations.compile
-    from project.configurations.compile
-    into "$buildDir/distributions/SOURCES"
-
-    doLast {
-        def tar = copySourceTar
-        println tar.outputs.files
-    }
-}
+// Matches Red Hat's naming convention of java-version-provider:
+// https://developers.redhat.com/articles/using-java-rhel-7-openjdk-8/
+def rpmName = 'java-11-amazon-corretto'
+// Matches the 'full version' from Java's release notes:
+// https://www.oracle.com/technetwork/java/javase/11-0-2-relnotes-5188746.html
+// Eg: 11.0.2+7
+def rpmVersion = "${version.major}.${version.minor}.${version.security}+${version.build}"
 
 /**
  * Apply version numbers to the RPM spec file template and copy
@@ -42,12 +39,14 @@ task copySourceTar(type: Copy) {
  */
 task inflateRpmSpec {
     inputs.file 'java-11-amazon-corretto.spec.template'
-    outputs.file "$buildDir/distributions/java-11-amazon-corretto.spec"
+    outputs.file "$buildDir/java-11-amazon-corretto.spec"
     doLast {
         def renderedTemplate = new GStringTemplateEngine()
                 .createTemplate(file('java-11-amazon-corretto.spec.template'))
                 .make(
                 [
+                        rpmName    : rpmName,
+                        rpmVersion : rpmVersion,
                         version    : project.version,
                         sourceTar  : project.configurations.compile.singleFile.name,
                         packageInfo: packageInfo
@@ -56,9 +55,18 @@ task inflateRpmSpec {
     }
 }
 
-artifacts {
-    archives(file("$buildDir/distributions")) {
-        builtBy inflateRpmSpec
-        builtBy copySourceTar
+task copySourceTar(type: Tar) {
+    dependsOn project.configurations.compile, inflateRpmSpec
+    compression Compression.GZIP
+    archiveName project.configurations.compile.singleFile.name
+    from("$buildDir") {
+        include 'java-11-amazon-corretto.spec'
+        into 'rpm'
     }
+    from tarTree(project.configurations.compile.singleFile)
+    into "$rpmName-$rpmVersion"
+}
+
+artifacts {
+    archives copySourceTar
 }

--- a/installers/linux/al2/spec/java-11-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-11-amazon-corretto.spec.template
@@ -38,11 +38,8 @@
 %global abs2rel %{__perl} -e %{script}
 
 Summary: Amazon Corretto development environment
-Name: java-11-amazon-corretto
-# Matches the 'full version' from Java's release notes:
-# https://www.oracle.com/technetwork/java/javase/11-0-2-relnotes-5188746.html
-# Eg: 11.0.2+7
-Version: ${version.major}.${version.minor}.${version.security}+${version.build}
+Name: ${rpmName}
+Version: ${rpmVersion}
 Release: ${version.revision}%{?dist}
 Epoch: 1
 Group: Development/Languages
@@ -57,6 +54,7 @@ ExclusiveArch: x86_64
 # For build, it provides the jvmdir macro. For runtime,
 # it provides the /usr/lib/jvm directory.
 BuildRequires: jpackage-utils
+BuildRequires: java-11-devel
 BuildRequires: autoconf
 BuildRequires: make
 BuildRequires: alsa-lib-devel
@@ -119,9 +117,10 @@ ${packageInfo.description}
 ${packageInfo.description} (Headless environment)
 
 %prep
-%setup -q -n src
+%setup -q
 
 %build
+cd src
 bash ./configure \\
         --with-jvm-features=zgc \\
         --with-version-feature="${version.major}" \\
@@ -146,7 +145,7 @@ make images
 %install
 rm -rf %{buildroot}
 install -d -m 755 %{buildroot}%{java_home}
-cp -a build/linux-%{_arch}-normal-server-release/images/jdk/* %{buildroot}%{java_home}
+cp -a src/build/linux-%{_arch}-normal-server-release/images/jdk/* %{buildroot}%{java_home}
 rm -rf %{buildroot}%{java_home}/demo
 
 # Make a *relative* symlink pointing to the cacerts file from ca-certificates.
@@ -189,7 +188,32 @@ if [ \$1 -eq 1 ] ; then
                --slave %{_bindir}/rmid rmid %{java_home}/bin/rmid \\
                --slave %{_bindir}/rmiregistry rmiregistry %{java_home}/bin/rmiregistry \\
                --slave %{_bindir}/serialver serialver %{java_home}/bin/serialver \\
-               --slave %{_bindir}/unpack200 unpack200 %{java_home}/bin/unpack200
+               --slave %{_bindir}/unpack200 unpack200 %{java_home}/bin/unpack200 \\
+               --slave %{_mandir}/man1/jar.1 jar.1 %{java_home}/man/man1/jar.1 \\
+               --slave %{_mandir}/man1/jarsigner.1 jarsigner.1 %{java_home}/man/man1/jarsigner.1 \\
+               --slave %{_mandir}/man1/java.1 java.1 %{java_home}/man/man1/java.1 \\
+               --slave %{_mandir}/man1/javac.1 javac.1 %{java_home}/man/man1/javac.1 \\
+               --slave %{_mandir}/man1/javadoc.1 javadoc.1 %{java_home}/man/man1/javadoc.1 \\
+               --slave %{_mandir}/man1/javap.1 javap.1 %{java_home}/man/man1/javap.1 \\
+               --slave %{_mandir}/man1/jcmd.1 jcmd.1 %{java_home}/man/man1/jcmd.1 \\
+               --slave %{_mandir}/man1/jconsole.1 jconsole.1 %{java_home}/man/man1/jconsole.1 \\
+               --slave %{_mandir}/man1/jdb.1 jdb.1 %{java_home}/man/man1/jdb.1 \\
+               --slave %{_mandir}/man1/jdeps.1 jdeps.1 %{java_home}/man/man1/jdeps.1 \\
+               --slave %{_mandir}/man1/jinfo.1 jinfo.1 %{java_home}/man/man1/jinfo.1 \\
+               --slave %{_mandir}/man1/jjs.1 jjs.1 %{java_home}/man/man1/jjs.1 \\
+               --slave %{_mandir}/man1/jmap.1 jmap.1 %{java_home}/man/man1/jmap.1 \\
+               --slave %{_mandir}/man1/jps.1 jps.1 %{java_home}/man/man1/jps.1 \\
+               --slave %{_mandir}/man1/jrunscript.1 jrunscript.1 %{java_home}/man/man1/jrunscript.1 \\
+               --slave %{_mandir}/man1/jstack.1 jstack.1 %{java_home}/man/man1/jstack.1 \\
+               --slave %{_mandir}/man1/jstat.1 jstat.1 %{java_home}/man/man1/jstat.1 \\
+               --slave %{_mandir}/man1/jstatd.1 jstatd.1 %{java_home}/man/man1/jstatd.1 \\
+               --slave %{_mandir}/man1/keytool.1 keytool.1 %{java_home}/man/man1/keytool.1 \\
+               --slave %{_mandir}/man1/pack200.1 pack200.1 %{java_home}/man/man1/pack200.1 \\
+               --slave %{_mandir}/man1/rmic.1 rmic.1 %{java_home}/man/man1/rmic.1 \\
+               --slave %{_mandir}/man1/rmid.1 rmid.1 %{java_home}/man/man1/rmid.1 \\
+               --slave %{_mandir}/man1/rmiregistry.1 rmiregistry.1 %{java_home}/man/man1/rmiregistry.1 \\
+               --slave %{_mandir}/man1/serialver.1 serialver.1 %{java_home}/man/man1/serialver.1 \\
+               --slave %{_mandir}/man1/unpack200.1 unpack200.1 %{java_home}/man/man1/unpack200.1
 fi
 
 %postun headless


### PR DESCRIPTION
Fixes #15, where Amazon Linux asked us to udpate the path in the source tarball that they use.

Additionally, I took this as an opportunity to update the testing Docker file to use the Corretto 11 official image.

Lastly, here's the rendered spec file corresponding to the GA (11.0.2.9.3).
```
# Copyright (c) 2019, Amazon.com, Inc. or its affiliates. All Rights Reserved.
# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
#
# This code is free software; you can redistribute it and/or modify it
# under the terms of the GNU General Public License version 2 only, as
# published by the Free Software Foundation. Amazon designates this
# particular file as subject to the "Classpath" exception as provided
# by Oracle in the LICENSE file that accompanied this code.
#
# This code is distributed in the hope that it will be useful, but WITHOUT
# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
# version 2 for more details (a copy is included in the LICENSE file that
# accompanied this code).
#
# You should have received a copy of the GNU General Public License version
# 2 along with this work; if not, write to the Free Software Foundation,
# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.


%global java_home %{_jvmdir}/%{name}.%{_arch}

# Higher numbers win for the alternatives program.
%global alternatives_priority 1000

# Instruct rpmbuild to copy jars rather than de-compress and re-compress.
%global __jar_repack 0

# Don't create a separate debug package. Specifically disables running
# this script:
# https://github.com/rpm-software-management/rpm/blob/master/scripts/find-debuginfo.sh
%define debug_package %{nil}

# abs2rel: A macro to convert an absolute path to a relative path.
# When making a symlink in an RPM, prefer a symbolic link to ensure
# the link will work in a chroot environment.
%global script 'use File::Spec; print File::Spec->abs2rel($ARGV[0], $ARGV[1])'
%global abs2rel %{__perl} -e %{script}

Summary: Amazon Corretto development environment
Name: java-11-amazon-corretto
# Matches the 'full version' from Java's release notes:
# https://www.oracle.com/technetwork/java/javase/11-0-2-relnotes-5188746.html
# Eg: 11.0.2+7
Version: 11.0.2+9
Release: 3%{?dist}
Epoch: 1
Group: Development/Languages
AutoReqProv: 0
License: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
Vendor: Amazon
Url: https://github.com/corretto/corretto-11
Source0: amazon-corretto-source-11.0.2.9.3.tar.gz
ExclusiveArch: x86_64

# jpackage-utils is required for both build and runtime.
# For build, it provides the jvmdir macro. For runtime,
# it provides the /usr/lib/jvm directory.
BuildRequires: jpackage-utils
BuildRequires: autoconf
BuildRequires: make
BuildRequires: alsa-lib-devel
BuildRequires: binutils
BuildRequires: which
BuildRequires: cups-devel
BuildRequires: fontconfig-devel
BuildRequires: freetype-devel
BuildRequires: giflib-devel
BuildRequires: gcc-c++
BuildRequires: libjpeg-devel
BuildRequires: libpng-devel
BuildRequires: libxslt
BuildRequires: libX11-devel
BuildRequires: libXi-devel
BuildRequires: libXinerama-devel
BuildRequires: libXt-devel
BuildRequires: libXrender-devel
BuildRequires: libXtst-devel
BuildRequires: pkgconfig
BuildRequires: xorg-x11-proto-devel

Requires: libX11
Requires: libXi
Requires: libXinerama
Requires: libXt
Requires: libXrender
Requires: libXtst
Requires: alsa-lib
Requires: giflib
Requires: libjpeg
Requires: libpng
Requires: dejavu-sans-fonts
Requires: dejavu-serif-fonts
Requires: dejavu-sans-mono-fonts
# Require headless package.
Requires: %{name}-headless%{?_isa} = %{epoch}:%{version}-%{release}


Provides: java = %{epoch}:11
Provides: java-11 = %{epoch}:11.0.2

%package headless
Summary: Amazon Corretto headless development environment
Group:   Development/Tools
AutoReqProv: 0

Requires: jpackage-utils
Requires: zlib
Requires: fontconfig
Requires: freetype
Requires: ca-certificates
Requires(post): chkconfig
Requires(postun): chkconfig

%description
Amazon Corretto's packaging of the runtime core elements of the OpenJDK 11 code.

%description headless
Amazon Corretto's packaging of the runtime core elements of the OpenJDK 11 code. (Headless environment)

%prep
%setup -q

%build
cd src
bash ./configure \
        --with-jvm-features=zgc \
        --with-version-feature="11" \
        --with-freetype=system \
        --with-libjpeg=system \
        --with-giflib=system \
        --with-libpng=system \
        --with-zlib=system \
        --with-version-opt= \
        --with-version-string="11.0.2" \
        --with-version-build="9" \
        --with-vendor-version-string="Corretto-11.0.2.9.3" \
        --with-version-pre= \
        --with-vendor-name="Amazon.com Inc." \
        --with-vendor-url="https://aws.amazon.com/corretto/" \
        --with-vendor-bug-url="https://github.com/corretto/corretto-11/issues/" \
        --with-debug-level=release \
        --with-native-debug-symbols=none

make images

%install
rm -rf %{buildroot}
install -d -m 755 %{buildroot}%{java_home}
cp -a src/build/linux-%{_arch}-normal-server-release/images/jdk/* %{buildroot}%{java_home}
rm -rf %{buildroot}%{java_home}/demo

# Make a *relative* symlink pointing to the cacerts file from ca-certificates.
rm -f %{buildroot}%{java_home}/lib/security/cacerts
pushd %{buildroot}%{java_home}/lib/security
  RELATIVE=$(%{abs2rel} %{_sysconfdir}/pki/java %{buildroot}%{java_home}/lib/security)
  ln -sf $RELATIVE/cacerts .
popd

%post headless
if [ $1 -eq 1 ] ; then
  alternatives --install %{_bindir}/java java %{java_home}/bin/java %{alternatives_priority} \
               --slave %{_bindir}/jaotc jaotc %{java_home}/bin/jaotc \
               --slave %{_bindir}/jar jar %{java_home}/bin/jar \
               --slave %{_bindir}/jarsigner jarsigner %{java_home}/bin/jarsigner \
               --slave %{_bindir}/javac javac %{java_home}/bin/javac \
               --slave %{_bindir}/javadoc javadoc %{java_home}/bin/javadoc \
               --slave %{_bindir}/javap javap %{java_home}/bin/javap \
               --slave %{_bindir}/jcmd jcmd %{java_home}/bin/jcmd \
               --slave %{_bindir}/jconsole jconsole %{java_home}/bin/jconsole \
               --slave %{_bindir}/jdb jdb %{java_home}/bin/jdb \
               --slave %{_bindir}/jdeprscan jdeprscan %{java_home}/bin/jdeprscan \
               --slave %{_bindir}/jdeps jdeps %{java_home}/bin/jdeps \
               --slave %{_bindir}/jhsdb jhsdb %{java_home}/bin/jhsdb \
               --slave %{_bindir}/jimage jimage %{java_home}/bin/jimage \
               --slave %{_bindir}/jinfo jinfo %{java_home}/bin/jinfo \
               --slave %{_bindir}/jjs jjs %{java_home}/bin/jjs \
               --slave %{_bindir}/jlink jlink %{java_home}/bin/jlink \
               --slave %{_bindir}/jmap jmap %{java_home}/bin/jmap \
               --slave %{_bindir}/jmod jmod %{java_home}/bin/jmod \
               --slave %{_bindir}/jps jps %{java_home}/bin/jps \
               --slave %{_bindir}/jrunscript jrunscript %{java_home}/bin/jrunscript \
               --slave %{_bindir}/jshell jshell %{java_home}/bin/jshell \
               --slave %{_bindir}/jstack jstack %{java_home}/bin/jstack \
               --slave %{_bindir}/jstat jstat %{java_home}/bin/jstat \
               --slave %{_bindir}/jstatd jstatd %{java_home}/bin/jstatd \
               --slave %{_bindir}/keytool keytool %{java_home}/bin/keytool \
               --slave %{_bindir}/pack200 pack200 %{java_home}/bin/pack200 \
               --slave %{_bindir}/rmic rmic %{java_home}/bin/rmic \
               --slave %{_bindir}/rmid rmid %{java_home}/bin/rmid \
               --slave %{_bindir}/rmiregistry rmiregistry %{java_home}/bin/rmiregistry \
               --slave %{_bindir}/serialver serialver %{java_home}/bin/serialver \
               --slave %{_bindir}/unpack200 unpack200 %{java_home}/bin/unpack200
fi

%postun headless
if [ $1 -eq 0 ] ; then
  alternatives --remove java %{java_home}/bin/java
fi

# The headfull variant adds RPM dependencies, but not files.
%files

%files headless
%{java_home}
```