### PR TITLE
Add jinfo file to Debian package

### DIFF
--- a/installers/linux/universal/deb/build.gradle
+++ b/installers/linux/universal/deb/build.gradle
@@ -33,6 +33,10 @@ def jdkHome = "${jvmDir}/${jdkInstallationDirName}".toString()
 def jdkBinaryDir = "${buildRoot}/amazon-corretto-${project.version.full}-linux-x64"
 def jdkPackageName = "java-${project.version.major}-amazon-corretto-jdk"
 
+def alternativesPriority = String.format("1%2s%2s%3s", project.version.major, project.version.minor, project.version.security).replace(' ', '0')
+
+def jinfoName = ".${jdkInstallationDirName}.jinfo"
+
 ospackage {
     // Valid version must start with a digit and only contain [A-Za-z0-9.+:~-]
     // See http://manpages.ubuntu.com/manpages/artful/en/man5/deb-version.5.html
@@ -70,18 +74,35 @@ task extractUniversalTar(type: Copy) {
  * Create script copies under build root scripts folder.
  */
 task inflateDebScriptTemplate(type: Copy) {
-    dependsOn extractUniversalTar 
+    dependsOn extractUniversalTar
     // In trusty repo, openjdk7 has priority 1071 and openjdk6 has 1061
     // Corretto uses the same priority in both rpm and deb
-    def priority = String.format("1%2s%2s%3s", project.version.major, project.version.minor, project.version.security).replace(' ', '0')
-    from('scripts') {
-        include '**/*.template'
-        rename { file -> file.replace('.template', '') }
-        filter(org.apache.tools.ant.filters.ReplaceTokens,
-                tokens: project.version + [java_home: jdkHome, alternatives_priority: priority,
-                                           jdk_tools: jdkTools.join(' ')])
-    }
+    def priority =
+            from('scripts') {
+                include '**/*.template'
+                rename { file -> file.replace('.template', '') }
+                filter(org.apache.tools.ant.filters.ReplaceTokens,
+                        tokens: project.version + [java_home: jdkHome, alternatives_priority: alternativesPriority,
+                                                   jdk_tools: jdkTools.join(' ')])
+            }
     into "${buildRoot}/scripts"
+}
+
+/**
+ * Inflate jinfo file used by update-java-alternatives command.
+ * Create script copy under buildRoot/jinfo folder. See
+ * http://manpages.ubuntu.com/manpages/xenial/man8/update-java-alternatives.8.html#files
+ */
+task inflateJinfoTemplate(type: Copy) {
+    from('jinfo') {
+        include '**/*.template'
+        rename('jinfo.template', jinfoName)
+        filter(org.apache.tools.ant.filters.ReplaceTokens,
+                tokens: project.version + [java_home     : jdkHome, alternatives_priority: alternativesPriority,
+                                           directory_name: jdkInstallationDirName.toString()])
+        expand(jdk_tools: jdkTools)
+    }
+    into "${buildRoot}/jinfo"
 }
 
 /**
@@ -91,6 +112,7 @@ task inflateDebScriptTemplate(type: Copy) {
 task generateJdkDeb(type: Deb) {
     description 'Create the DEB package for Corretto JDK'
     dependsOn inflateDebScriptTemplate
+    dependsOn inflateJinfoTemplate
 
     packageName jdkPackageName
     packageDescription "Amazon Corretto\'s packaging of the OpenJDK ${project.version.major} code."
@@ -109,6 +131,11 @@ task generateJdkDeb(type: Deb) {
 
     from(jdkBinaryDir) {
         into jdkHome
+    }
+
+    from("$buildRoot/jinfo") {
+        include '**/*.jinfo'
+        into jvmDir
     }
 }
 

--- a/installers/linux/universal/deb/jinfo/jinfo.template
+++ b/installers/linux/universal/deb/jinfo/jinfo.template
@@ -1,0 +1,7 @@
+name=@directory_name@
+alias=@directory_name@
+priority=@alternatives_priority@
+section=main
+
+<% jdk_tools.each {%>jdk ${it} @java_home@/bin/${it}
+<%}%>


### PR DESCRIPTION
Include jinfo file in deb packaging to support `update-java-alternatives` command.



### Description
When packaging deb package, inflate jinfo template and copy it to /usr/lib/jvm/ directory. Make it possible to update Corretto alternatives through update-java-alternatives command.

```
name=java-11-amazon-corretto
alias=java-11-amazon-corretto
priority=11100002
section=main

jdk java /usr/lib/jvm/java-11-amazon-corretto/bin/java
jdk keytool /usr/lib/jvm/java-11-amazon-corretto/bin/keytool
jdk rmid /usr/lib/jvm/java-11-amazon-corretto/bin/rmid
jdk rmiregistry /usr/lib/jvm/java-11-amazon-corretto/bin/rmiregistry
jdk jjs /usr/lib/jvm/java-11-amazon-corretto/bin/jjs
jdk pack200 /usr/lib/jvm/java-11-amazon-corretto/bin/pack200
jdk unpack200 /usr/lib/jvm/java-11-amazon-corretto/bin/unpack200
jdk javac /usr/lib/jvm/java-11-amazon-corretto/bin/javac
jdk jaotc /usr/lib/jvm/java-11-amazon-corretto/bin/jaotc
jdk jlink /usr/lib/jvm/java-11-amazon-corretto/bin/jlink
jdk jmod /usr/lib/jvm/java-11-amazon-corretto/bin/jmod
jdk jhsdb /usr/lib/jvm/java-11-amazon-corretto/bin/jhsdb
jdk jar /usr/lib/jvm/java-11-amazon-corretto/bin/jar
jdk jarsigner /usr/lib/jvm/java-11-amazon-corretto/bin/jarsigner
jdk javadoc /usr/lib/jvm/java-11-amazon-corretto/bin/javadoc
jdk javap /usr/lib/jvm/java-11-amazon-corretto/bin/javap
jdk jcmd /usr/lib/jvm/java-11-amazon-corretto/bin/jcmd
jdk jconsole /usr/lib/jvm/java-11-amazon-corretto/bin/jconsole
jdk jdb /usr/lib/jvm/java-11-amazon-corretto/bin/jdb
jdk jdeps /usr/lib/jvm/java-11-amazon-corretto/bin/jdeps
jdk jdeprscan /usr/lib/jvm/java-11-amazon-corretto/bin/jdeprscan
jdk jimage /usr/lib/jvm/java-11-amazon-corretto/bin/jimage
jdk jinfo /usr/lib/jvm/java-11-amazon-corretto/bin/jinfo
jdk jmap /usr/lib/jvm/java-11-amazon-corretto/bin/jmap
jdk jps /usr/lib/jvm/java-11-amazon-corretto/bin/jps
jdk jrunscript /usr/lib/jvm/java-11-amazon-corretto/bin/jrunscript
jdk jshell /usr/lib/jvm/java-11-amazon-corretto/bin/jshell
jdk jstack /usr/lib/jvm/java-11-amazon-corretto/bin/jstack
jdk jstat /usr/lib/jvm/java-11-amazon-corretto/bin/jstat
jdk jstatd /usr/lib/jvm/java-11-amazon-corretto/bin/jstatd
jdk rmic /usr/lib/jvm/java-11-amazon-corretto/bin/rmic
jdk serialver /usr/lib/jvm/java-11-amazon-corretto/bin/serialver
```

### Related issues
[#25](https://github.com/corretto/corretto-11/issues/25)

### How has this been tested?

Built deb package with command `./gradlew :installers:linux:universal:deb:build`. Install Corretto deb package and Debian default openjdk on Ububtu 18.04 container.

List java alternatives:

```
root@bab5fd1d5137:/corretto# update-java-alternatives --list
java-1.11.0-openjdk-amd64      1111       /usr/lib/jvm/java-1.11.0-openjdk-amd64
java-11-amazon-corretto        11100002   /usr/lib/jvm/java-11-amazon-corretto
```

Switch to Corretto:

```
root@bab5fd1d5137:/corretto# update-java-alternatives -s java-11-amazon-corretto
root@bab5fd1d5137:/corretto# java -version
openjdk version "11.0.2" 2019-01-15 LTS
OpenJDK Runtime Environment Corretto-11.0.2.9.3 (build 11.0.2+9-LTS)
OpenJDK 64-Bit Server VM Corretto-11.0.2.9.3 (build 11.0.2+9-LTS, mixed mode)
```

Switch to Ubuntu OpenJDK:

```
root@bab5fd1d5137:/corretto# update-java-alternatives -s java-1.11.0-openjdk-amd64
root@bab5fd1d5137:/corretto# java -version
openjdk version "11.0.3" 2019-04-16
OpenJDK Runtime Environment (build 11.0.3+7-Ubuntu-1ubuntu218.04.1)
OpenJDK 64-Bit Server VM (build 11.0.3+7-Ubuntu-1ubuntu218.04.1, mixed mode, sharing)
```
