### PR TITLE
Don't include OpenJDK's cacerts in Linux's tar distribution.

### DIFF
--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -88,7 +88,8 @@ task configureBuild(type: Exec) {
         "--with-vendor-bug-url=https://github.com/corretto/corretto-${version.major}/issues/",
         '--with-debug-level=release',
         '--with-native-debug-symbols=none',
-        '--with-stdc++lib=static'
+        '--with-stdc++lib=static',
+        "--with-cacerts-file=$buildRoot/cacerts"
 }
 
 task executeBuild(type: Exec) {
@@ -119,10 +120,6 @@ task packageBuildResults(type: Tar) {
         include 'lib/**'
         include 'man/man1/**'
         include 'release'
-    }
-    from(buildRoot) {
-        include 'cacerts'
-        into 'lib/security'
     }
     into "amazon-corretto-${project.version.full}-linux-${arch_alias}"
 }


### PR DESCRIPTION
Fixes #29.

## Checks:

1. Output from listing contents of tar:

```bash
➜  corretto-11 git:(develop) ✗ tar -tvzf installers/linux/universal/tar/corretto-build/distributions/amazon-corretto-11.0.3.7.1-linux-x64.tar.gz | grep cacert
-rw-r--r-- 0/0          183421 2019-06-12 15:50 amazon-corretto-11.0.3.7.1-linux-x64/lib/security/cacerts
```

2. Comparison of our cacerts to the one included in the extracted tar:

```bash
➜  pr sha256sum amazon-corretto-11.0.3.7.1-linux-x64/lib/security/cacerts 
bb471c15a288db084d7b980e22dc59184184d3ba4e700f395cd14bcc1ff7bd68  amazon-corretto-11.0.3.7.1-linux-x64/lib/security/cacerts
➜  corretto-11 git:(develop) ✗ sha256sum cacerts 
bb471c15a288db084d7b980e22dc59184184d3ba4e700f395cd14bcc1ff7bd68  cacerts
```