### PR TITLE
Support building rpm and deb on aarch64

### DIFF
--- a/installers/linux/universal/deb/build.gradle
+++ b/installers/linux/universal/deb/build.gradle
@@ -27,10 +27,30 @@ dependencies {
     compile project(path: ':installers:linux:universal:tar', configuration: 'archives')
 }
 
+ext {
+    // all linux distros and macos support 'uname -m'
+    arch = ['uname', '-m'].execute().text.trim()
+
+    switch (arch) {
+        case 'aarch64':
+            arch_alias = arch
+            // Ubuntu arch designation for 64bit ARM is arm64
+            arch_deb = 'arm64'
+            break
+        case 'x86_64':
+            arch_alias = 'x64'
+            // Ubuntu arch designation for AMD64 & Intel 64 is amd64
+            arch_deb = 'amd64'
+            break
+        default:
+            throw new GradleException("${arch} is not suported")
+    }
+}
+
 def jvmDir = '/usr/lib/jvm'
 def jdkInstallationDirName = "java-${project.version.major}-amazon-corretto"
 def jdkHome = "${jvmDir}/${jdkInstallationDirName}".toString()
-def jdkBinaryDir = "${buildRoot}/amazon-corretto-${project.version.full}-linux-x64"
+def jdkBinaryDir = "${buildRoot}/amazon-corretto-${project.version.full}-linux-${arch_alias}"
 def jdkPackageName = "java-${project.version.major}-amazon-corretto-jdk"
 
 ospackage {
@@ -50,7 +70,7 @@ ospackage {
     user 'root'
     permissionGroup 'root'
     epoch 1
-    arch 'amd64'
+    arch arch_deb
     multiArch SAME
 }
 

--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -19,18 +19,67 @@
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-plugins {
-    id "nebula.ospackage" version "5.2.0"
+import java.nio.file.Paths
+
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+
+    // An utility method to download jar from url.
+    def urlDeps = { urlStr ->
+        def url = new URL(urlStr)
+        def name = Paths.get(url.getPath()).getFileName().toString()
+        File file = new File("$buildDir/download/${name}")
+        file.parentFile.mkdirs()
+        if (!file.exists()) {
+            url.withInputStream { downloadStream ->
+                file.withOutputStream { fileOut ->
+                    fileOut << downloadStream
+                }
+            }
+        }
+        files(file.absolutePath)
+    }
+
+    dependencies {
+        classpath urlDeps('https://github.com/corretto/redline/releases/download/redline-1.2.8/redline-1.2.8.jar')
+        classpath("com.netflix.nebula:gradle-ospackage-plugin:5.2.0") {
+            exclude group: 'org.redline-rpm', module: 'redline'
+        }
+    }
 }
 
 dependencies {
     compile project(path: ':installers:linux:universal:tar', configuration: 'archives')
 }
 
+apply plugin: "nebula.ospackage"
+
+ext {
+    // all linux distros and macos support 'uname -m'
+    arch = ['uname', '-m'].execute().text.trim()
+
+    switch (arch) {
+        case 'aarch64':
+            arch_redline = 'AARCH64'
+            arch_alias = arch
+            break;
+        case 'x86_64':
+            arch_redline = arch
+            arch_alias = 'x64'
+            break;
+        default:
+            throw new GradleException("${arch} is not suported")
+    }
+}
+
 def jvmDir = '/usr/lib/jvm'
 def jdkInstallationDirName = "java-${project.version.major}-amazon-corretto"
 def jdkHome = "${jvmDir}/${jdkInstallationDirName}"
-def jdkBinaryDir = "${buildRoot}/amazon-corretto-${project.version.full}-linux-x64"
+def jdkBinaryDir = "${buildRoot}/amazon-corretto-${project.version.full}-linux-${arch_alias}"
 def jdkPackageName = "java-${project.version.major}-amazon-corretto-devel"
 
 ospackage {
@@ -45,7 +94,7 @@ ospackage {
     user 'root'
     permissionGroup 'root'
     epoch 1
-    arch X86_64
+    arch "${arch_redline}"
     os LINUX
     type BINARY
 }


### PR DESCRIPTION
This is ported from Corretto-8:
* Add support for building rpm package on aarch64 ([28881b6](https://github.com/corretto/corretto-8/commit/28881b6811ec28624eaa47d85fd5f884e526694f))
* Add support for building deb package on aarch64 ([e0a8172](https://github.com/corretto/corretto-8/commit/e0a817207b54cf0c86f78dc03ed7221efd600910))

### Test

Test performed in a CentOS7 aarch64 docker:
```
# ./gradlew :installers:linux:universal:tar:build
# ./gradlew :installers:linux:universal:rpm:build
# ./gradlew :installers:linux:universal:deb:build
# ls -l installers/linux/universal/*/corretto-build/distributions
installers/linux/universal/deb/corretto-build/distributions:
total 185004
-rw-r--r-- 1 root root       825 Jun 20 18:20 java-11-amazon-corretto-jdk_11.0.3.7-1_arm64.changes
-rw-r--r-- 1 root root 189438710 Jun 20 18:20 java-11-amazon-corretto-jdk_11.0.3.7-1_arm64.deb

installers/linux/universal/rpm/corretto-build/distributions:
total 185024
-rw-r--r-- 1 root root 189463791 Jun 20 18:17 java-11-amazon-corretto-devel-11.0.3.7-1.aarch64.rpm

installers/linux/universal/tar/corretto-build/distributions:
total 185056
-rw-r--r-- 1 root root 189496465 Jun 20 18:09 amazon-corretto-11.0.3.7.1-linux-aarch64.tar.gz
```