### PR TITLE
Removed IOException from the `close()` method signature

### DIFF
--- a/src/src/java.base/share/classes/java/io/StringWriter.java
+++ b/src/src/java.base/share/classes/java/io/StringWriter.java
@@ -238,7 +238,7 @@ public class StringWriter extends Writer {
      * class can be called after the stream has been closed without generating
      * an {@code IOException}.
      */
-    public void close() throws IOException {
+    public void close() {
     }
 
 }


### PR DESCRIPTION
### Description

The problem with the close() throwing `IOException` can be seen when
using the try-with-resources statement introduced with Java 7: the
compiler will require a useless (hence detrimental) catch block, or to
declare the IOException on the enclosing method.

Example:

```
void testClose() {

    try (StringWriter writer = new StringWriter()) {
        // do something with writer
    }

    //  Compiler reports:

    //  unreported exception java.io.IOException; must be caught or
    //  declared to be thrown
    //  exception thrown from implicit call to close() on resource
    //  variable 'writer'

    // so we need to write the unnecessary code below to handle an
    // exception which will never be thrown from the empty close()
    // method:

    catch (IOException e) {
        e.printStackTrace();
    }
}
```

There are already some classes extending from `java.io.Writer` that do
not declare the `IOException` on the method signature:

- CharArrayWriter
- PrintWriter

The `AutoCloseable` interface from which the `close()` signature is
inherited, in fact throws `java.lang.Exception` but it's always a good
idea to restrict the exceptions in the signature of the implementing
classes to the strictly necessary ones.

Workaround: in my project I implemented a class like this one:

```
/**
 * Fixes JDK class that does nothing on close() but declares to throw
 * IOException on close().
 */
public class StringWriter extends java.io.StringWriter {
    /**
     * Same implementation on {@link java.io.StringWriter#close()} but
     * without throwing {@link java.io.IOException}
     */
    @Override
    public void close() {
    }
}
```

So that the catch block is not needed.


### Related issues


### Motivation and context

The Exception on the method signature requires useless code (catch block, or declaring the exception on the enclosing method)

### How has this been tested?

The compiler reports an error for a missing catch block, which is not required. Once the the method signature has been cleaned, the unnecessary code is no more required.

### Platform information
    Works on OS: all jdk
    Applies to version from 7 to 13.


### Additional context

Existing code might report "exception java.io.IOException is never thrown in body of corresponding try statement" if the IOException is catched. If the IOException is passed outside from the enclosing method
there would be no impact (but some IDEs will report that the exception can be removed from the method signature). 
