### PR TITLE
corretto-8#190: Add provides for earlier jdks in debian

### DIFF
--- a/installers/linux/universal/deb/build.gradle
+++ b/installers/linux/universal/deb/build.gradle
@@ -142,12 +142,29 @@ task generateJdkDeb(type: Deb) {
     preUninstall file("$buildRoot/scripts/preun_jdk.sh")
 
     requires('java-common')
+    // jdk
     provides('java-compiler')
-    provides('java-runtime')
     provides('java-sdk')
-
+    provides('java5-sdk')
+    provides('java6-sdk')
+    provides('java7-sdk')
+    provides('java7-jdk')
+    provides('java8-jdk')
     provides('java11-sdk')
+    // TODO: Move this to the jre when splitting the fat deb
+    provides('java-runtime')
+    provides('java5-runtime')
+    provides('java6-runtime')
+    provides('java7-runtime')
+    provides('java8-runtime')
     provides('java11-runtime')
+    // TODO: Move this to the headless jre when splitting the fat deb
+    provides('java-runtime-headless')
+    provides('java5-runtime-headless')
+    provides('java6-runtime-headless')
+    provides('java7-runtime-headless')
+    provides('java8-runtime-headless')
+    provides('java11-runtime-headless')
 
     from(jdkBinaryDir) {
         into jdkHome


### PR DESCRIPTION
This commits add provides for both headful and headless runtime for Java 5 to 8 in Corretto-11. This is the 11 port of the PR [corretto-8#199](https://github.com/corretto/corretto-8/pull/199).