### PR TITLE
Inital .gitignore to ignore build dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+corretto-build/


### PR DESCRIPTION
### Description
Adding a .gitignore to ignore build dirs

### Motivation and context
Removes unnecessary "untracked files" when working in the git repo.

### How has this been tested?

1. Added `.gitignore`
2. Run `git status`
3. Build directories no long show as untracked files
