### PR TITLE
Updating version strings to recommended formats

### DIFF
--- a/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template
+++ b/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template
@@ -164,7 +164,7 @@
         <key>USE_HFS+_COMPRESSION</key>
         <false/>
         <key>VERSION</key>
-        <string>1.0</string>
+        <string>@full@</string>
       </dict>
       <key>TYPE</key>
       <integer>0</integer>

--- a/installers/mac/tar/templates/Info.plist.template
+++ b/installers/mac/tar/templates/Info.plist.template
@@ -17,7 +17,7 @@
         <key>CFBundlePackageType</key>
         <string>BNDL</string>
         <key>CFBundleShortVersionString</key>
-        <string>@major@.@minor@.@security@</string>
+        <string>1.0</string>
         <key>CFBundleSignature</key>
         <string>????</string>
         <key>CFBundleVersion</key>

--- a/installers/mac/tar/templates/Info.plist.template
+++ b/installers/mac/tar/templates/Info.plist.template
@@ -17,11 +17,11 @@
         <key>CFBundlePackageType</key>
         <string>BNDL</string>
         <key>CFBundleShortVersionString</key>
-        <string>1.0</string>
+        <string>@major@.@minor@.@security@</string>
         <key>CFBundleSignature</key>
         <string>????</string>
         <key>CFBundleVersion</key>
-        <string>11.@minor@.@security@</string>
+        <string>@full@</string>
         <key>JavaVM</key>
         <dict>
                 <key>JVMCapabilities</key>


### PR DESCRIPTION
### Description
This update is to properly set version strings in the necessary locations in order to allow for software distribution management software to properly detect the version installed. This is necessary to determine if the version installed requires an update to a newer version.

### Motivation and context 
macOS maintains a database of receipts for installed software. These receipts include package identifiers and installed versions of software. Software distribution management software, such as the open source project [Munki](https://github.com/munki/munki) uses this information to determine what version of the software is currently installed, and to determine if there is a newer version available to upgrade.

Currently, Corretto 11 is always setting this value to `1.0`. [Reference](https://github.com/corretto/corretto-11/blob/56ddb281a9609fbca54ef0d22a5dbae80463980d/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template#L166-L167)
```
$ pkgutil --pkg-info com.amazon.corretto.11
package-id: com.amazon.corretto.11
version: 1.0
```

This pull request includes a fix to always change this value to the `full` version number (essentially the contents of `version.txt`, eg. 11.0.5.10.2).

Furthermore, this pull request includes changes to the Info.plist used in the bundle to help properly identify the version of the bundle. These formats follow industry best practices and Apple's recommendations. 

- [CFBundleVersion](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion) 
- [CFBundleVersion (archive)](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364)
- [CFBundleShortVersionString](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring)
- [CFBundleShortVersionString (archive)](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-111349)

### How has this been tested?
Local builds and installs on macOS Mojave 10.14.6 (18G2022)

### Platform information
This is specific to macOS