### PR TITLE
Move version numbers to variables

### DIFF
--- a/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template
+++ b/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template
@@ -45,7 +45,7 @@
                           <key>GID</key>
                           <integer>0</integer>
                           <key>PATH</key>
-                          <string>amazon-corretto-11.jdk</string>
+                          <string>amazon-corretto-@major@.jdk</string>
                           <key>PATH_TYPE</key>
                           <integer>1</integer>
                           <key>PERMISSIONS</key>
@@ -148,11 +148,11 @@
         <key>FOLLOW_SYMBOLIC_LINKS</key>
         <false/>
         <key>IDENTIFIER</key>
-        <string>com.amazon.corretto.11</string>
+        <string>com.amazon.corretto.@major@</string>
         <key>LOCATION</key>
         <integer>0</integer>
         <key>NAME</key>
-        <string>amazon-corretto-11.jdk</string>
+        <string>amazon-corretto-@major@.jdk</string>
         <key>OVERWRITE_PERMISSIONS</key>
         <false/>
         <key>PAYLOAD_SIZE</key>
@@ -363,7 +363,7 @@
             <key>LANGUAGE</key>
             <string>English</string>
             <key>VALUE</key>
-            <string>Amazon Corretto 11</string>
+            <string>Amazon Corretto @major@</string>
           </dict>
         </array>
       </dict>

--- a/installers/mac/tar/templates/Info.plist.template
+++ b/installers/mac/tar/templates/Info.plist.template
@@ -9,11 +9,11 @@
         <key>CFBundleGetInfoString</key>
         <string>Amazon Corretto @full@-LTS</string>
         <key>CFBundleIdentifier</key>
-        <string>com.amazon.corretto.11</string>
+        <string>com.amazon.corretto.@major@</string>
         <key>CFBundleInfoDictionaryVersion</key>
         <string>7.0</string>
         <key>CFBundleName</key>
-        <string>Amazon Corretto 11</string>
+        <string>Amazon Corretto @major@</string>
         <key>CFBundlePackageType</key>
         <string>BNDL</string>
         <key>CFBundleShortVersionString</key>
@@ -21,7 +21,7 @@
         <key>CFBundleSignature</key>
         <string>????</string>
         <key>CFBundleVersion</key>
-        <string>11.@minor@.@security@</string>
+        <string>@major@.@minor@.@security@</string>
         <key>JavaVM</key>
         <dict>
                 <key>JVMCapabilities</key>
@@ -33,11 +33,11 @@
                 <key>JVMMinimumSystemVersion</key>
                 <string>10.6.0</string>
                 <key>JVMPlatformVersion</key>
-                <string>11.0</string>
+                <string>@major@.@minor@</string>
                 <key>JVMVendor</key>
                 <string>Amazon.com Inc.</string>
                 <key>JVMVersion</key>
-                <string>11.@minor@.@security@</string>
+                <string>@major@.@minor@.@security@</string>
         </dict>
 </dict>
 </plist>

--- a/installers/mac/tar/templates/Info.plist.template
+++ b/installers/mac/tar/templates/Info.plist.template
@@ -21,7 +21,7 @@
         <key>CFBundleSignature</key>
         <string>????</string>
         <key>CFBundleVersion</key>
-        <string>@major@.@minor@.@security@</string>
+        <string>@full@</string>
         <key>JavaVM</key>
         <dict>
                 <key>JVMCapabilities</key>


### PR DESCRIPTION
### Description
Switches hard coded version numbers to variables. This allows for easier portability of code and transitions to new versions.

### Related issues
This will help prevent issues like #10 

### Motivation and context
This should help with releasing new versions of Corretto as they become available to ensure consistency of version numbers across the macOS packages.

### How has this been tested?
Local builds and installs on macOS Mojave 10.14.6 (18G2022)

### Platform information
Specifically targeting macOS.

### Additional context
If accepted, I will work on porting over to Corretto 8 as well.