### PR TITLE
Changing distribution filename to macos

### DIFF
--- a/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template
+++ b/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template
@@ -557,7 +557,7 @@
         </dict>
       </array>
       <key>NAME</key>
-      <string>amazon-corretto-@full@-macosx-x64</string>
+      <string>amazon-corretto-@full@-macos-x64</string>
       <key>PAYLOAD_ONLY</key>
       <false/>
       <key>REFERENCE_FOLDER_PATH</key>

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -132,7 +132,7 @@ task prepareArtifacts {
 
 task packaging(type: Exec) {
     dependsOn prepareArtifacts
-    String tarDir = "${distributionDir}/amazon-corretto-${project.version.full}-macosx-x64.tar.gz"
+    String tarDir = "${distributionDir}/amazon-corretto-${project.version.full}-macos-x64.tar.gz"
     workingDir buildDir
     commandLine "tar", "czf", tarDir, correttoMacDir
     outputs.file tarDir


### PR DESCRIPTION
### Description
Starting with macOS Sierra 10.12, Mac OS X/OS X has officially been renamed macOS. This PR reflects that change by removing the "x" in "macosx" from the generated macOS distribution files.

### Motivation and context
It appears that the permanent links provided at https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html have already dropped the "x" from "macosx". This helps keep that consistent.

### How has this been tested?
Local builds and installs on macOS Mojave 10.14.6 (18G2022)

### Platform information
Only affects macOS distributions.

### Additional context
If accepted, this change will also be made to Corretto 8.