### PR TITLE
Update build logic to handle certificates post build

### DIFF
--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -39,20 +39,8 @@ task copySource(type: Copy) {
     into buildRoot
 }
 
-task importAmazonCacerts(type: Exec) {
-    dependsOn copySource
-    workingDir buildRoot
-    // Default password for JSSE key store
-    def keystore_password = "changeit"
-    commandLine 'keytool', '-importkeystore', '-noprompt',
-            '-srckeystore', "amazon-cacerts",
-            '-srcstorepass', keystore_password,
-            '-destkeystore', 'src/src/java.base/share/lib/security/cacerts',
-            '-deststorepass', keystore_password
-}
-
 task configureBuild(type: Exec) {
-    dependsOn importAmazonCacerts
+    dependsOn copySource
     workingDir "$buildRoot/src"
     def commands = ['bash', 'configure',
                     '--with-jvm-features=zgc',
@@ -64,8 +52,7 @@ task configureBuild(type: Exec) {
                     '--with-vendor-url=https://aws.amazon.com/corretto/',
                     "--with-vendor-bug-url=https://github.com/corretto/corretto-${version.major}/issues/",
                     '--with-debug-level=release',
-                    '--with-native-debug-symbols=none',
-                    "--with-cacerts-file=$buildRoot/src/src/java.base/share/lib/security/cacerts"]
+                    '--with-native-debug-symbols=none']
     def extraCmd = System.getenv("EXTRA_CORRETTO_CONFIG_OPTIONS")
     if (extraCmd != null) {
         commands += extraCmd.split(" ")
@@ -80,8 +67,20 @@ task executeBuild(type: Exec) {
     outputs.dir jdkResultingImage
 }
 
-task renameBuildArtifacts {
+task importAmazonCacerts(type: Exec) {
     dependsOn executeBuild
+    workingDir "${jdkResultingImage}/jdk-${version.major}.${version.minor}.${version.security}.jdk/Contents/Home/"
+    // Default password for JSSE key store
+    def keystore_password = "changeit"
+    commandLine 'keytool', '-importkeystore', '-noprompt',
+            '-srckeystore', "${buildRoot}/amazon-cacerts",
+            '-srcstorepass', keystore_password,
+            '-destkeystore', 'lib/security/cacerts',
+            '-deststorepass', keystore_password
+}
+
+task renameBuildArtifacts {
+    dependsOn importAmazonCacerts
     doLast {
         file("${jdkResultingImage}/jdk-${version.major}.${version.minor}.${version.security}.jdk").
                 renameTo(file("${jdkResultingImage}/${correttoMacDir}"))

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -42,20 +42,9 @@ task copySource(type: Copy) {
     into buildRoot
 }
 
-task importAmazonCacerts(type: Exec) {
-    dependsOn copySource
-    workingDir buildRoot
-    // Default password for JSSE key store
-    def keystore_password = "changeit"
-    commandLine 'keytool', '-importkeystore', '-noprompt',
-            '-srckeystore', "amazon-cacerts",
-            '-srcstorepass', keystore_password,
-            '-destkeystore', 'src/src/java.base/share/lib/security/cacerts',
-            '-deststorepass', keystore_password
-}
 
 task configureBuild(type: Exec) {
-    dependsOn importAmazonCacerts
+    dependsOn copySource
     workingDir "$buildRoot/src"
 
     commandLine 'bash', 'configure',
@@ -77,8 +66,7 @@ task configureBuild(type: Exec) {
             "--with-debug-level=release",
             "--with-native-debug-symbols=none",
             "--with-stdc++lib=static",
-            "--with-msvcr-dll=${project.getProperty('vcruntime_dir')}/vcruntime140.dll",
-            "--with-cacerts-file=$buildRoot/src/src/java.base/share/lib/security/cacerts"
+            "--with-msvcr-dll=${project.getProperty('vcruntime_dir')}/vcruntime140.dll"
 }
 
 task executeBuild(type: Exec) {
@@ -88,8 +76,20 @@ task executeBuild(type: Exec) {
     commandLine 'make', 'clean', 'images'
 }
 
-task copyImage(type: Copy) {
+task importAmazonCacerts(type: Exec) {
     dependsOn executeBuild
+    workingDir "${executeBuild.workingDir}/build/windows-$folder_alias-normal-server-release/images/jdk"
+    // Default password for JSSE key store
+    def keystore_password = "changeit"
+    commandLine 'keytool', '-importkeystore', '-noprompt',
+            '-srckeystore', "${buildRoot}/amazon-cacerts",
+            '-srcstorepass', keystore_password,
+            '-destkeystore', 'lib/security/cacerts',
+            '-deststorepass', keystore_password
+}
+
+task copyImage(type: Copy) {
+    dependsOn importAmazonCacerts
 
     from "${executeBuild.workingDir}/build/windows-$folder_alias-normal-server-release/images"
     into "$buildRoot/build"


### PR DESCRIPTION
### Description
Mac and Windows build logic would provide the cacerts file before build.
This change will update the logic to merge the cacerts file post build.

### How has this been tested?
Validated that the cacerts file are created as expected.

### Platform information
MacOS and Windows