### PR TITLE
backport of 8234863: Increase default value of MaxInlineLevel

### DIFF
--- a/src/src/hotspot/share/runtime/globals.hpp
+++ b/src/src/hotspot/share/runtime/globals.hpp
@@ -1674,7 +1674,7 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
   notproduct(intx, MaxSubklassPrintSize, 4,                                 \
           "maximum number of subklasses to print when printing klass")      \
                                                                             \
-  product(intx, MaxInlineLevel, 9,                                          \
+  product(intx, MaxInlineLevel, 15,                                         \
           "maximum number of nested calls that are inlined")                \
           range(0, max_jint)                                                \
                                                                             \


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto 11.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 11
and is not specific to Corretto 11,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 11,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
increase MaxInlineLevel from 9 to 15. 

### Related issues


### Motivation and context
[PackedIntsDecodeBenchmark.readLongs ](https://github.com/jpountz/decode-128-ints-benchmark/blob/master/src/main/java/jpountz/NoopDecoder.java)will increase 20%+.

### How has this been tested?


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "11.0.1+13-1" (see output from "java -version")]


### Additional context
