### PR TITLE
Add support for test image on Linux and macOS

### DIFF
--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -41,6 +41,7 @@ ext {
 }
 
 def jdkResultingImage = "$buildRoot/src/build/linux-${arch}-normal-server-release/images/jdk"
+def testResultingImage = "$buildRoot/src/build/linux-${arch}-normal-server-release/images/test"
 
 /**
  * Create a local copy of the source tree in our
@@ -110,9 +111,27 @@ task importAmazonCacerts(type: Exec) {
                 '-deststorepass', keystore_password
 }
 
+task createTestImage(type: Exec) {
+    dependsOn executeBuild
+    workingDir "$buildRoot/src"
+    commandLine 'make','test-image-hotspot-jtreg-native','test-image-jdk-jtreg-native','test-image-hotspot-gtest'
+}
+
+task packageTestImage(type: Tar) {
+    dependsOn createTestImage
+    description 'Package test results'
+    archiveName "amazon-corretto-testimage-${project.version.full}-linux-${arch_alias}.tar.gz"
+    compression Compression.GZIP
+    from(testResultingImage) {
+        include '**'
+    }
+    into "amazon-corretto-testimage-${project.version.full}-linux-${arch_alias}"
+
+}
+
 task packageBuildResults(type: Tar) {
     description 'Compresses the JDK image and puts the results in build/distributions.'
-    dependsOn executeBuild
+    dependsOn packageTestImage
     dependsOn importAmazonCacerts
     archiveName "amazon-corretto-${project.version.full}-linux-${arch_alias}.tar.gz"
     compression Compression.GZIP

--- a/installers/mac/pkg/build.gradle
+++ b/installers/mac/pkg/build.gradle
@@ -30,7 +30,14 @@ task retrieveArtifacts(type: Exec) {
     workingDir buildRoot
     if (artifactsPath == null) {
         dependsOn project.configurations.compile
-        commandLine "tar", "xf", "${project.configurations.compile.singleFile}"
+        // The tar module produces multiple tars. We only extract the JDK tgz
+        def artifacts = project.configurations.compile.getFiles()
+        for (File tgz in artifacts) {
+            if (tgz.getName().matches("amazon-corretto-${project.version.major}(.+)-macosx-x64\\.tar\\.gz")) {
+                commandLine "tar", "xf", tgz
+                break
+            }
+        }
     } else {
         commandLine "cp", "-Rf", "${artifactsPath}", buildRoot
     }

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -23,7 +23,9 @@ dependencies {
     compile project(path: ':openjdksrc', configuration: 'archives')
 }
 
-def jdkResultingImage = "$buildRoot/src/build/macosx-x86_64-normal-server-release/images/jdk-bundle"
+def imageDir= "${buildRoot}/src/build/macosx-x86_64-normal-server-release/images"
+def jdkResultingImage = "${imageDir}/jdk-bundle"
+def testResultingImage = "${imageDir}/test"
 def correttoMacDir = 'amazon-corretto-11.jdk'
 
 /**
@@ -60,11 +62,21 @@ task configureBuild(type: Exec) {
     commandLine commands.flatten()
 }
 
-task executeBuild(type: Exec) {
+task executeBuild {
     dependsOn configureBuild
-    workingDir "$buildRoot/src"
-    commandLine 'make', 'images'
-    outputs.dir jdkResultingImage
+    def workspace = "$buildRoot/src"
+    doLast {
+        // Build image
+        exec {
+            workingDir workspace
+            commandLine 'make', 'images'
+        }
+        // Build tests
+        exec {
+            workingDir workspace
+            commandLine 'make','test-image-hotspot-jtreg-native','test-image-jdk-jtreg-native','test-image-hotspot-gtest'
+        }
+    }
 }
 
 task importAmazonCacerts(type: Exec) {
@@ -131,12 +143,26 @@ task prepareArtifacts {
 
 task packaging(type: Exec) {
     dependsOn prepareArtifacts
-    String tarDir = "${distributionDir}/amazon-corretto-${project.version.full}-macosx-x64.tar.gz"
+    def tarDir = "${distributionDir}/amazon-corretto-${project.version.full}-macosx-x64.tar.gz"
     workingDir buildDir
     commandLine "tar", "czf", tarDir, correttoMacDir
     outputs.file tarDir
 }
 
+task packageTestResults(type: Tar) {
+    dependsOn executeBuild
+    def archive = "amazon-corretto-testimage-${project.version.full}-macosx-x64"
+    description 'Package test results'
+    archiveName "${archive}.tar.gz"
+    compression Compression.GZIP
+    from(testResultingImage) {
+        include '**'
+    }
+    into archive
+
+}
+
 artifacts {
     archives file: packaging.outputs.getFiles().getSingleFile(), builtBy: packaging
+    archives packageTestResults
 }


### PR DESCRIPTION
Some Jtreg tests in Corretto 11 requires native libraries. These native libraries are built by the target `test-image-hotspot-jtreg-native`, `test-image-jdk-jtreg-native`, `test-image-hotspot-gtest`. This PR adds Gradle tasks to generate the native libraries as part of the build process on Linux and macOS.

### Tests
Tests have been performed on Linux & macOS. The target tar `amazon-corretto-testimage-<full_version>-<platform>.tar.gz` was generated correctly.