### PR TITLE
Fix missing Amazon cacerts in java.base.jmod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .gradle/
 corretto-build/
+pre-build/

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,71 @@ allprojects {
         jdkTools = ['java', 'keytool', 'rmid', 'rmiregistry', 'jjs', 'pack200', 'unpack200', 'javac', 'jaotc', 'jlink',
             'jmod', 'jhsdb', 'jar', 'jarsigner', 'javadoc', 'javap', 'jcmd', 'jconsole', 'jdb', 'jdeps', 'jdeprscan',
             'jimage', 'jinfo', 'jmap', 'jps', 'jrunscript', 'jshell', 'jstack', 'jstat', 'jstatd', 'rmic', 'serialver']
+        // artifact names
+        caCerts = "cacerts"
+        sourceTar = "amazon-corretto-source-${project.version.full}.tar.gz"
+    }
+}
+
+project(':prebuild') {
+    apply plugin: 'java'
+
+    configurations {
+        cacerts
+    }
+
+    ext {
+        cacertDir = "$distributionDir/${project.caCerts}"
+    }
+
+    def preBuildSrc = "src"
+    def classPath = "classes"
+    def generateToolMain = "build.tools.generatecacerts.GenerateCacerts"
+
+    task copyToolSrc(type: Copy) {
+        description 'Copy utility tool source to the project root'
+        from fileTree("$rootDir/src/make/jdk/src/classes") {
+            include 'build/tools/generatecacerts/*'
+        }
+        into preBuildSrc
+    }
+
+    task buildTool(type: JavaCompile) {
+        dependsOn copyToolSrc
+        source = fileTree(dir: preBuildSrc, include: '**/*.java')
+        destinationDir = file(classPath)
+        classpath = files(classPath)
+    }
+
+    task generateJdkCacerts(type: JavaExec) {
+        dependsOn buildTool
+        def jdkCaDir = "$rootDir/src/make/data/cacerts"
+
+        description = 'Generate Cacerts from JDK source'
+        classpath = files(classPath)
+        main = generateToolMain
+        args = [jdkCaDir, project.caCerts]
+    }
+
+    task importAmazonCacerts(type: Exec) {
+        dependsOn generateJdkCacerts
+        // Default password for JSSE key store
+        def keystore_password = "changeit"
+        commandLine 'keytool', '-importkeystore', '-noprompt',
+                '-srckeystore', "$rootDir/amazon-cacerts",
+                '-srcstorepass', keystore_password,
+                '-destkeystore', caCerts,
+                '-deststorepass', keystore_password
+    }
+
+    task copyCacerts(type: Copy) {
+        dependsOn importAmazonCacerts
+        from caCerts
+        into distributionDir
+    }
+
+    artifacts {
+        cacerts file: file("$distributionDir/${caCerts}"), builtBy: copyCacerts
     }
 }
 
@@ -71,7 +136,7 @@ project(':openjdksrc') {
     task sourceDistributionTarball(type: Tar) {
         description 'Assemble source files required for building and distributing Corretto.'
         compression Compression.GZIP
-        archiveName "amazon-corretto-source-${project.version.full}.tar.gz"
+        archiveName sourceTar
         from fileTree(rootDir) {
             include 'src/**'
             exclude 'src/corretto-build/**'

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -22,6 +22,7 @@
 
 dependencies {
     compile project(path: ':openjdksrc', configuration: 'archives')
+    compile project(path: ':prebuild', configuration: 'cacerts')
 }
 
 ext {
@@ -43,6 +44,9 @@ ext {
 def jdkResultingImage = "$buildRoot/src/build/linux-${arch}-normal-server-release/images/jdk"
 def testResultingImage = "$buildRoot/src/build/linux-${arch}-normal-server-release/images/test"
 
+// deps
+def depsMap = [:]
+project.configurations.compile.getFiles().each { depsMap[it.getName()] = it }
 /**
  * Create a local copy of the source tree in our
  * build root -- this is required since OpenJDK's
@@ -52,7 +56,7 @@ def testResultingImage = "$buildRoot/src/build/linux-${arch}-normal-server-relea
  */
 task copySource(type: Copy) {
     dependsOn project.configurations.compile
-    from tarTree(project.configurations.compile.singleFile)
+    from tarTree(depsMap[sourceTar])
     into buildRoot
 }
 
@@ -89,7 +93,8 @@ task configureBuild(type: Exec) {
         "--with-vendor-bug-url=https://github.com/corretto/corretto-${version.major}/issues/",
         '--with-debug-level=release',
         '--with-native-debug-symbols=none',
-        '--with-stdc++lib=static'
+        '--with-stdc++lib=static',
+        "--with-cacerts-file=${depsMap[caCerts]}"
 }
 
 task executeBuild(type: Exec) {
@@ -97,18 +102,6 @@ task executeBuild(type: Exec) {
     workingDir "$buildRoot/src"
     commandLine 'make', 'images'
     outputs.dir jdkResultingImage
-}
-
-task importAmazonCacerts(type: Exec) {
-    dependsOn executeBuild
-    workingDir jdkResultingImage
-    // Default password for JSSE key store
-    def keystore_password = "changeit"
-    commandLine 'bin/keytool', '-importkeystore', '-noprompt',
-                '-srckeystore', "${buildRoot}/amazon-cacerts",
-                '-srcstorepass', keystore_password,
-                '-destkeystore', 'lib/security/cacerts',
-                '-deststorepass', keystore_password
 }
 
 task createTestImage(type: Exec) {
@@ -132,7 +125,6 @@ task packageTestImage(type: Tar) {
 task packageBuildResults(type: Tar) {
     description 'Compresses the JDK image and puts the results in build/distributions.'
     dependsOn packageTestImage
-    dependsOn importAmazonCacerts
     archiveName "amazon-corretto-${project.version.full}-linux-${arch_alias}.tar.gz"
     compression Compression.GZIP
     from(buildRoot) {

--- a/installers/mac/pkg/build.gradle
+++ b/installers/mac/pkg/build.gradle
@@ -20,7 +20,7 @@
 */
 
 dependencies {
-    compile project(path: ':installers:mac:tar', configuration: 'archives')
+    compile project(path: ':installers:mac:tar', configuration: 'buildTar')
 }
 
 // Copy task cannot be used here because Gradle does not preserve the symlink
@@ -30,14 +30,7 @@ task retrieveArtifacts(type: Exec) {
     workingDir buildRoot
     if (artifactsPath == null) {
         dependsOn project.configurations.compile
-        // The tar module produces multiple tars. We only extract the JDK tgz
-        def artifacts = project.configurations.compile.getFiles()
-        for (File tgz in artifacts) {
-            if (tgz.getName().matches("amazon-corretto-${project.version.major}(.+)-macosx-x64\\.tar\\.gz")) {
-                commandLine "tar", "xf", tgz
-                break
-            }
-        }
+        commandLine "tar", "xf", project.configurations.compile.singleFile
     } else {
         commandLine "cp", "-Rf", "${artifactsPath}", buildRoot
     }

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -21,12 +21,24 @@
 
 dependencies {
     compile project(path: ':openjdksrc', configuration: 'archives')
+    compile project(path: ':prebuild', configuration: 'cacerts')
 }
 
+// Two configurations for tgz & Jtreg native library respectively.
+// Separate artifacts to simplify the artifacts fetching in :mac:pkg.
+configurations {
+    buildTar
+    testLib
+}
+// consts
 def imageDir= "${buildRoot}/src/build/macosx-x86_64-normal-server-release/images"
 def jdkResultingImage = "${imageDir}/jdk-bundle"
 def testResultingImage = "${imageDir}/test"
 def correttoMacDir = 'amazon-corretto-11.jdk'
+
+// deps
+def depsMap = [:]
+project.configurations.compile.getFiles().each { depsMap[it.getName()] = it }
 
 /**
  * Create a local copy of the source tree in our
@@ -37,7 +49,7 @@ def correttoMacDir = 'amazon-corretto-11.jdk'
  */
 task copySource(type: Copy) {
     dependsOn project.configurations.compile
-    from tarTree(project.configurations.compile.singleFile)
+    from tarTree(depsMap[sourceTar])
     into buildRoot
 }
 
@@ -54,7 +66,8 @@ task configureBuild(type: Exec) {
                     '--with-vendor-url=https://aws.amazon.com/corretto/',
                     "--with-vendor-bug-url=https://github.com/corretto/corretto-${version.major}/issues/",
                     '--with-debug-level=release',
-                    '--with-native-debug-symbols=none']
+                    '--with-native-debug-symbols=none',
+                    "--with-cacerts-file=${depsMap[caCerts]}"]
     def extraCmd = System.getenv("EXTRA_CORRETTO_CONFIG_OPTIONS")
     if (extraCmd != null) {
         commands += extraCmd.split(" ")
@@ -79,20 +92,8 @@ task executeBuild {
     }
 }
 
-task importAmazonCacerts(type: Exec) {
-    dependsOn executeBuild
-    workingDir "${jdkResultingImage}/jdk-${version.major}.${version.minor}.${version.security}.jdk/Contents/Home/"
-    // Default password for JSSE key store
-    def keystore_password = "changeit"
-    commandLine 'keytool', '-importkeystore', '-noprompt',
-            '-srckeystore', "${buildRoot}/amazon-cacerts",
-            '-srcstorepass', keystore_password,
-            '-destkeystore', 'lib/security/cacerts',
-            '-deststorepass', keystore_password
-}
-
 task renameBuildArtifacts {
-    dependsOn importAmazonCacerts
+    dependsOn executeBuild
     doLast {
         file("${jdkResultingImage}/jdk-${version.major}.${version.minor}.${version.security}.jdk").
                 renameTo(file("${jdkResultingImage}/${correttoMacDir}"))
@@ -163,6 +164,6 @@ task packageTestResults(type: Tar) {
 }
 
 artifacts {
-    archives file: packaging.outputs.getFiles().getSingleFile(), builtBy: packaging
-    archives packageTestResults
+    buildTar file: packaging.outputs.getFiles().getSingleFile(), builtBy: packaging
+    testLib packageTestResults
 }

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -21,6 +21,7 @@
 
 dependencies {
     compile project(path: ':openjdksrc', configuration: 'archives')
+    compile project(path: ':prebuild', configuration: 'cacerts')
 }
 
 ext {
@@ -36,9 +37,13 @@ ext {
     }
 }
 
+// deps
+def depsMap = [:]
+project.configurations.compile.getFiles().each { depsMap[it.getName()] = it }
+
 task copySource(type: Copy) {
     dependsOn project.configurations.compile
-    from tarTree(project.configurations.compile.singleFile)
+    from tarTree(depsMap[sourceTar])
     into buildRoot
 }
 
@@ -66,7 +71,8 @@ task configureBuild(type: Exec) {
             "--with-debug-level=release",
             "--with-native-debug-symbols=none",
             "--with-stdc++lib=static",
-            "--with-msvcr-dll=${project.getProperty('vcruntime_dir')}/vcruntime140.dll"
+            "--with-msvcr-dll=${project.getProperty('vcruntime_dir')}/vcruntime140.dll",
+            "--with-cacerts-file=${depsMap[caCerts]}"
 }
 
 task executeBuild(type: Exec) {
@@ -76,20 +82,8 @@ task executeBuild(type: Exec) {
     commandLine 'make', 'clean', 'images'
 }
 
-task importAmazonCacerts(type: Exec) {
-    dependsOn executeBuild
-    workingDir "${executeBuild.workingDir}/build/windows-$folder_alias-normal-server-release/images/jdk"
-    // Default password for JSSE key store
-    def keystore_password = "changeit"
-    commandLine 'keytool', '-importkeystore', '-noprompt',
-            '-srckeystore', "${buildRoot}/amazon-cacerts",
-            '-srcstorepass', keystore_password,
-            '-destkeystore', 'lib/security/cacerts',
-            '-deststorepass', keystore_password
-}
-
 task copyImage(type: Copy) {
-    dependsOn importAmazonCacerts
+    dependsOn executeBuild
 
     from "${executeBuild.workingDir}/build/windows-$folder_alias-normal-server-release/images"
     into "$buildRoot/build"

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ rootProject.name = 'corretto11'
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-def subProjects = [':openjdksrc']
+def subProjects = [':openjdksrc', ':prebuild']
 
 if (Os.isFamily(Os.FAMILY_MAC)) {
     subProjects += [':installers:mac:pkg',
@@ -20,3 +20,4 @@ if (Os.isFamily(Os.FAMILY_MAC)) {
 include subProjects as String[]
 
 project(':openjdksrc').projectDir = file('src')
+project(':prebuild').projectDir = file('pre-build')


### PR DESCRIPTION
This commit fixes the cacert issue reported in corretto-11 #88 

The original gradle task attempts to append Amazon certs to the JDK cacerts under `$JAVA_HOME/lib/security` as a post-build step. In fact, there are two copies of the cert file in `lib/security` and `java.base.jmod` respectively. Patching files in jmod is non-trivial, therefore this commit tries to build the cacerts as a pre-build step. The cacerts file is generated by a new configuration `:prebuild:cacerts`.

### Tests
This commit has been verified on Windows, Linux (x64) and macOS:
```
$ bin/keytool -list -rfc -cacerts -storepass changeit | grep "Your keystore contains"
Your keystore contains 220 entries
```