### PR TITLE
Support debug build and refactor common gradle logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@
 // Tasks can refer to version information using the project.version
 // property. For an example of its usage, see ':installers:linux:rpm:buildLogic'
 // where the version numbers are used to populate a templated RPM spec file.
+
+import org.apache.tools.ant.taskdefs.condition.Os
+
 allprojects {
     apply plugin: 'base'
 
@@ -64,6 +67,103 @@ allprojects {
         // artifact names
         caCerts = "cacerts"
         sourceTar = "amazon-corretto-source-${project.version.full}.tar.gz"
+
+        correttoCommonFlags = [
+                "--with-freetype=bundled",
+                '--with-jvm-features=zgc',
+                "--with-version-build=${project.version.build}",
+                '--with-version-opt=LTS',
+                '--with-version-pre=',
+                "--with-version-string=${version.major}.${version.minor}.${version.security}",
+                "--with-vendor-bug-url=https://github.com/corretto/corretto-${project.version.major}/issues/",
+                '--with-vendor-name=Amazon.com Inc.',
+                '--with-vendor-url=https://aws.amazon.com/corretto/',
+                "--with-vendor-version-string=Corretto-${project.version.full}"
+        ]
+
+        // Valid value: null, release, debug, fastdebug, slowdebug
+        def correttoDebugLevel = "release" // Default: release
+        switch(project.findProperty("corretto.debug_level")) {
+            case null:
+            case "release":
+                correttoCommonFlags += ['--with-debug-level=release', '--with-native-debug-symbols=none']
+                break
+            case "fastdebug":
+                correttoDebugLevel = "fastdebug"
+                correttoCommonFlags += ['--with-debug-level=fastdebug', '--with-native-debug-symbols=zipped']
+                break
+            case "debug":
+            case "slowdebug":
+                correttoDebugLevel = "slowdebug"
+                correttoCommonFlags += ['--with-debug-level=slowdebug', '--with-native-debug-symbols=external']
+                break
+            default:
+                throw new RuntimeException("Invalid corretto.debug_level")
+        }
+
+        // customized flags. Identify the index of double dashes as the start of a flag
+        String extraConfig = project.findProperty("corretto.extra_config")
+        def lastIndex = -1
+        if (extraConfig != null) {
+            for (int index = extraConfig.indexOf("--"); index >= 0; index = extraConfig.indexOf("--", index + 1)) {
+                if (lastIndex != -1) {
+                    correttoCommonFlags += extraConfig.substring(lastIndex, index).trim()
+                }
+                lastIndex = index
+            }
+            if (lastIndex != -1) {
+                correttoCommonFlags += extraConfig.substring(lastIndex).trim()
+            }
+        }
+
+        // Determine the system architecture
+        def jdkArch = ""
+        def os = ""
+        if (Os.isFamily(Os.FAMILY_MAC)) {
+            os = 'macosx'
+            jdkArch = "x86_64"
+        } else if (Os.isFamily(Os.FAMILY_UNIX)) {
+            os = 'linux'
+            jdkArch = ['uname', '-m'].execute().text.trim()
+            // `uname -m` returns the host arch in a linux x86 docker instance. Pass a flag
+            // to enable
+            if (project.hasProperty("x86") && Boolean.parseBoolean(project.getProperty('x86'))) {
+                jdkArch = "x86"
+            }
+        } else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            def arch = System.getenv('PROCESSOR_ARCHITECTURE')
+            if (arch == 'AMD64') {
+                jdkArch = "x86_64"
+            } else { //x86
+                throw new GradleException("${arch} is not suported")
+            }
+        } else {
+            throw new GradleException("OS is not supported")
+        }
+
+        // Ext property: correttoArch
+        switch (jdkArch) {
+            case 'x86':
+            case 'aarch64':
+                correttoArch = jdkArch
+                break
+            case 'x86_64':
+                correttoArch = 'x64'
+                break
+            default:
+                throw new GradleException("${jdkArch} is not supported")
+        }
+
+        // Call toString explicitly to avoid lazy evaluation
+        jdkImageName = "${os}-${jdkArch}-normal-server-${correttoDebugLevel}".toString()
+        // no debug level suffix for release build
+        if (correttoDebugLevel == "release") {
+            correttoJdkArchiveName = "amazon-corretto-${project.version.full}-${os}-${correttoArch}".toString()
+        } else {
+            correttoJdkArchiveName =
+                    "amazon-corretto-${project.version.full}-${os}-${correttoArch}-${correttoDebugLevel}".toString()
+        }
+        correttoTestImageArchiveName = "amazon-corretto-testimage-${project.version.full}-${os}-${correttoArch}".toString()
     }
 }
 

--- a/installers/linux/universal/deb/build.gradle
+++ b/installers/linux/universal/deb/build.gradle
@@ -28,39 +28,23 @@ dependencies {
 }
 
 ext {
-    // all linux distros and macos support 'uname -m'
-    arch = ['uname', '-m'].execute().text.trim()
-    is_x86 = false
-    if (project.hasProperty("x86")) {
-        is_x86 = Boolean.valueOf("${project.getProperty('x86')}")
-    }
-
-    switch (arch) {
+    switch (project.correttoArch) {
         case 'aarch64':
-            arch_alias = arch
-            // Ubuntu arch designation for 64bit ARM is arm64
             arch_deb = 'arm64'
+            break;
+        case 'x86':
+            arch_deb = "i386"
             break
-        case 'x86_64':
-            if(is_x86) {
-                arch = 'x86'
-                arch_alias = 'x86'
-                arch_deb = "i386"
-            } else {
-                arch_alias = 'x64'
-                // Ubuntu arch designation for AMD64 & Intel 64 is amd64
-                arch_deb = 'amd64'
-            }
+        case 'x64':
+            arch_deb = 'amd64'
             break
-        default:
-            throw new GradleException("${arch} is not suported")
     }
 }
 
 def jvmDir = '/usr/lib/jvm'
 def jdkInstallationDirName = "java-${project.version.major}-amazon-corretto"
 def jdkHome = "${jvmDir}/${jdkInstallationDirName}".toString()
-def jdkBinaryDir = "${buildRoot}/amazon-corretto-${project.version.full}-linux-${arch_alias}"
+def jdkBinaryDir = "${buildRoot}/${project.correttoJdkArchiveName}"
 def jdkPackageName = "java-${project.version.major}-amazon-corretto-jdk"
 
 def alternativesPriority = String.format("1%2s%2s%3s", project.version.major, project.version.minor, project.version.security).replace(' ', '0')

--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -28,37 +28,23 @@ dependencies {
 }
 
 ext {
-    // all linux distros and macos support 'uname -m'
-    arch = ['uname', '-m'].execute().text.trim()
-    is_x86 = false
-    if (project.hasProperty("x86")) {
-        is_x86 = Boolean.valueOf("${project.getProperty('x86')}")
-    }
-
-    switch (arch) {
+    switch (project.correttoArch) {
         case 'aarch64':
             arch_redline = 'AARCH64'
-            arch_alias = arch
             break;
-        case 'x86_64':
-            if(is_x86) {
-                arch = 'x86'
-                arch_redline = "i386"
-                arch_alias = 'x86'
-            } else {
-                arch_redline = arch
-                arch_alias = 'x64'
-            }
-            break;
-        default:
-            throw new GradleException("${arch} is not suported")
+        case 'x86':
+            arch_redline = "i386"
+            break
+        case 'x64':
+            arch_redline = 'x86_64'
+            break
     }
 }
 
 def jvmDir = '/usr/lib/jvm'
 def jdkInstallationDirName = "java-${project.version.major}-amazon-corretto"
 def jdkHome = "${jvmDir}/${jdkInstallationDirName}"
-def jdkBinaryDir = "${buildRoot}/amazon-corretto-${project.version.full}-linux-${arch_alias}"
+def jdkBinaryDir = "${buildRoot}/${project.correttoJdkArchiveName}"
 def jdkPackageName = "java-${project.version.major}-amazon-corretto-devel"
 
 ospackage {
@@ -73,7 +59,7 @@ ospackage {
     user 'root'
     permissionGroup 'root'
     epoch 1
-    arch "${arch_redline}"
+    arch arch_redline
     os LINUX
     type BINARY
 }

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -25,35 +25,13 @@ dependencies {
     compile project(path: ':prebuild', configuration: 'cacerts')
 }
 
-ext {
-    // all linux distros and macos support 'uname -m'
-    arch = ['uname', '-m'].execute().text.trim()
-    is_x86 = false
-    if (project.hasProperty("x86")) {
-        is_x86 = Boolean.valueOf("${project.getProperty('x86')}")
-    }
-
-	switch (arch) {
-	case 'aarch64':
-		arch_alias = arch
-		break;
-	case 'x86_64':
-        if (is_x86) {
-            arch = 'x86'
-            arch_alias = 'x86'
-            with_target_bit = "--with-target-bits=32"
-        } else {
-		    arch_alias = 'x64'
-            with_target_bit = "--with-target-bits=64"
-        }
-		break;
-	default:
-		throw new GradleException("${arch} is not suported")
-    }
+if (project.correttoArch == 'x86') {
+    project.correttoCommonFlags += '--with-target-bits=32'
 }
 
-def jdkResultingImage = "$buildRoot/src/build/linux-${arch}-normal-server-release/images/jdk"
-def testResultingImage = "$buildRoot/src/build/linux-${arch}-normal-server-release/images/test"
+def imageDir= "$buildRoot/src/build/${project.jdkImageName}/images"
+def jdkResultingImage = "${imageDir}/jdk"
+def testResultingImage = "${imageDir}/test"
 
 // deps
 def depsMap = [:]
@@ -89,24 +67,16 @@ task applyPatches() {
 task configureBuild(type: Exec) {
     dependsOn applyPatches
     workingDir "$buildRoot/src"
-    commandLine 'bash', 'configure',
-        '--with-jvm-features=zgc',
-        "--with-version-feature=${version.major}",
-        '--with-freetype=bundled',
-        '--with-zlib=bundled',
-        '--with-version-opt=LTS',
-        "--with-version-string=${version.major}.${version.minor}.${version.security}",
-        "--with-version-build=${version.build}",
-        "--with-vendor-version-string=Corretto-${version.full}",
-        '--with-version-pre=',
-        '--with-vendor-name=Amazon.com Inc.',
-        '--with-vendor-url=https://aws.amazon.com/corretto/',
-        "--with-vendor-bug-url=https://github.com/corretto/corretto-${version.major}/issues/",
-        '--with-debug-level=release',
-        '--with-native-debug-symbols=none',
-        '--with-stdc++lib=static',
-        "--with-cacerts-file=${depsMap[caCerts]}",
-        "${with_target_bit}"
+
+    // Platform specific flags
+    def command = ['bash', 'configure',
+            "--with-cacerts-file=${depsMap[caCerts]}",
+            "--with-zlib=bundled"
+    ]
+    // Common flags
+    command += project.correttoCommonFlags
+    commandLine command.flatten()
+
 }
 
 task executeBuild(type: Exec) {
@@ -125,19 +95,19 @@ task createTestImage(type: Exec) {
 task packageTestImage(type: Tar) {
     dependsOn createTestImage
     description 'Package test results'
-    archiveName "amazon-corretto-testimage-${project.version.full}-linux-${arch_alias}.tar.gz"
+    archiveName "${project.correttoTestImageArchiveName}.tar.gz"
     compression Compression.GZIP
     from(testResultingImage) {
         include '**'
     }
-    into "amazon-corretto-testimage-${project.version.full}-linux-${arch_alias}"
+    into project.correttoTestImageArchiveName
 
 }
 
 task packageBuildResults(type: Tar) {
     description 'Compresses the JDK image and puts the results in build/distributions.'
     dependsOn packageTestImage
-    archiveName "amazon-corretto-${project.version.full}-linux-${arch_alias}.tar.gz"
+    archiveName "${project.correttoJdkArchiveName}.tar.gz"
     compression Compression.GZIP
     from(buildRoot) {
         include 'ADDITIONAL_LICENSE_INFO'
@@ -156,7 +126,7 @@ task packageBuildResults(type: Tar) {
         include 'man/man1/**'
         include 'release'
     }
-    into "amazon-corretto-${project.version.full}-linux-${arch_alias}"
+    into project.correttoJdkArchiveName
 }
 
 artifacts {

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -31,10 +31,11 @@ configurations {
     testLib
 }
 // consts
-def imageDir= "${buildRoot}/src/build/macosx-x86_64-normal-server-release/images"
+def imageDir= "$buildRoot/src/build/${project.jdkImageName}/images"
 def jdkResultingImage = "${imageDir}/jdk-bundle"
 def testResultingImage = "${imageDir}/test"
-def correttoMacDir = 'amazon-corretto-11.jdk'
+def correttoMacDir = "amazon-corretto-${project.version.major}.jdk"
+
 
 // deps
 def depsMap = [:]
@@ -56,23 +57,14 @@ task copySource(type: Copy) {
 task configureBuild(type: Exec) {
     dependsOn copySource
     workingDir "$buildRoot/src"
-    def commands = ['bash', 'configure',
-                    '--with-jvm-features=zgc',
-                    '--with-version-opt=LTS',
-                    "--with-version-build=${version.build}",
-                    "--with-vendor-version-string=Corretto-${version.full}",
-                    '--with-version-pre=',
-                    '--with-vendor-name=Amazon.com Inc.',
-                    '--with-vendor-url=https://aws.amazon.com/corretto/',
-                    "--with-vendor-bug-url=https://github.com/corretto/corretto-${version.major}/issues/",
-                    '--with-debug-level=release',
-                    '--with-native-debug-symbols=none',
-                    "--with-cacerts-file=${depsMap[caCerts]}"]
-    def extraCmd = System.getenv("EXTRA_CORRETTO_CONFIG_OPTIONS")
-    if (extraCmd != null) {
-        commands += extraCmd.split(" ")
-    }
-    commandLine commands.flatten()
+
+    // Platform specific flags
+    def command = ['bash', 'configure',
+            "--with-cacerts-file=${depsMap[caCerts]}"
+    ]
+    // Common flags
+    command += project.correttoCommonFlags
+    commandLine command.flatten()
 }
 
 task executeBuild {
@@ -144,7 +136,7 @@ task prepareArtifacts {
 
 task packaging(type: Exec) {
     dependsOn prepareArtifacts
-    def tarDir = "${distributionDir}/amazon-corretto-${project.version.full}-macosx-x64.tar.gz"
+    String tarDir = "${distributionDir}/${project.correttoJdkArchiveName}.tar.gz"
     workingDir buildDir
     commandLine "tar", "czf", tarDir, correttoMacDir
     outputs.file tarDir
@@ -152,14 +144,13 @@ task packaging(type: Exec) {
 
 task packageTestResults(type: Tar) {
     dependsOn executeBuild
-    def archive = "amazon-corretto-testimage-${project.version.full}-macosx-x64"
     description 'Package test results'
-    archiveName "${archive}.tar.gz"
+    archiveName "${project.correttoTestImageArchiveName}.tar.gz"
     compression Compression.GZIP
     from(testResultingImage) {
         include '**'
     }
-    into archive
+    into project.correttoTestImageArchiveName
 
 }
 

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -24,19 +24,6 @@ dependencies {
     compile project(path: ':prebuild', configuration: 'cacerts')
 }
 
-ext {
-    arch = System.getenv('PROCESSOR_ARCHITECTURE')
-
-    switch(arch) {
-        case 'AMD64':
-            arch_alias = 'x64'
-            folder_alias = 'x86_64'
-            break;
-        default:
-            throw new GradleException("${arch} is not suported")
-    }
-}
-
 // deps
 def depsMap = [:]
 project.configurations.compile.getFiles().each { depsMap[it.getName()] = it }
@@ -52,27 +39,18 @@ task configureBuild(type: Exec) {
     dependsOn copySource
     workingDir "$buildRoot/src"
 
-    commandLine 'bash', 'configure',
-            "--with-boot-jdk=${project.getProperty('bootjdk_dir')}",
-            "--with-ucrt-dll-dir=${project.getProperty('ucrt_dll_dir')}",
-            "--with-jtreg=${project.getProperty('jtreg_dir')}",
-            "--with-jvm-features=zgc",
-            "--with-freetype=bundled",
-            "--with-zlib=bundled",
-            "--with-version-opt=LTS",
-            "--with-version-feature=${project.version.major}",
-            "--with-version-string=${project.version.major}.${project.version.minor}.${project.version.security}",
-            "--with-version-build=${project.version.build}",
-            "--with-vendor-version-string=Corretto-${project.version.full}",
-            "--with-version-pre=",
-            "--with-vendor-name=Amazon.com Inc.",
-            "--with-vendor-url=https://aws.amazon.com/corretto/",
-            "--with-vendor-bug-url=https://github.com/corretto/corretto-11/issues/",
-            "--with-debug-level=release",
-            "--with-native-debug-symbols=none",
-            "--with-stdc++lib=static",
-            "--with-msvcr-dll=${project.getProperty('vcruntime_dir')}/vcruntime140.dll",
-            "--with-cacerts-file=${depsMap[caCerts]}"
+    // Platform specific flags
+    def command = ['bash', 'configure',
+           "--with-cacerts-file=${depsMap[caCerts]}",
+           "--with-boot-jdk=${project.getProperty('bootjdk_dir')}",
+           "--with-ucrt-dll-dir=${project.getProperty('ucrt_dll_dir')}",
+           "--with-jtreg=${project.getProperty('jtreg_dir')}",
+           "--with-msvcr-dll=${project.getProperty('vcruntime_dir')}/vcruntime140.dll",
+           "--with-zlib=bundled"
+    ]
+    // Common flags
+    command += project.correttoCommonFlags
+    commandLine command.flatten()
 }
 
 task executeBuild(type: Exec) {
@@ -85,7 +63,7 @@ task executeBuild(type: Exec) {
 task copyImage(type: Copy) {
     dependsOn executeBuild
 
-    from "${executeBuild.workingDir}/build/windows-$folder_alias-normal-server-release/images"
+    from "${executeBuild.workingDir}/build/${project.jdkImageName}/images"
     into "$buildRoot/build"
 }
 


### PR DESCRIPTION
Add two properties to control build behavior:
corretto.debug_level - Control the debug level of the build. Valid
options including: release, fastdebug, debug, slowdebug.
corretto.extra_config - Pass extra configuration flags to the build.

This is the corretto-11 counterpart of [corretto-8#239](https://github.com/corretto/corretto-8/pull/239)

### Tests
* Linux x86 (slowdebug)
```
./gradlew -Px86=true -Pcorretto.debug_level=debug :installers:linux:universal:deb:build :installers:linux:universal:rpm:build
...
[root@af1061c584ad corretto-11]# ls installers/linux/universal/*/corretto-build/distributions
installers/linux/universal/deb/corretto-build/distributions:
java-11-amazon-corretto-jdk_11.0.7.10-1_i386.changes  java-11-amazon-corretto-jdk_11.0.7.10-1_i386.deb

installers/linux/universal/rpm/corretto-build/distributions:
java-11-amazon-corretto-devel-11.0.7.10-1.i386.rpm

installers/linux/universal/tar/corretto-build/distributions:
amazon-corretto-11.0.7.10.1-linux-x86-slowdebug.tar.gz  amazon-corretto-testimage-11.0.7.10.1-linux-x86.tar.gz
```
* Linux x64 (fastdebug & release)
```
./gradlew -Pcorretto.debug_level=fastdebug :installers:linux:universal:deb:build :installers:linux:universal:rpm:build
...
[root@d28fca373706 corretto-11]# ls installers/linux/universal/*/corretto-build/distributions
installers/linux/universal/deb/corretto-build/distributions:
java-11-amazon-corretto-jdk_11.0.7.10-1_amd64.changes  java-11-amazon-corretto-jdk_11.0.7.10-1_amd64.deb

installers/linux/universal/rpm/corretto-build/distributions:
java-11-amazon-corretto-devel-11.0.7.10-1.x86_64.rpm

installers/linux/universal/tar/corretto-build/distributions:
amazon-corretto-11.0.7.10.1-linux-x64-fastdebug.tar.gz  amazon-corretto-testimage-11.0.7.10.1-linux-x64.tar.gz
```
* MacOS (release) - Succeeded