### PR TITLE
Use rsync for mac & linux build instead of extracting source from the tgz

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ allprojects {
         // artifact names
         caCerts = "cacerts"
         sourceTar = "amazon-corretto-source-${project.version.full}.tar.gz"
+        sourceDir = project(':openjdksrc').projectDir
 
         correttoCommonFlags = [
                 "--with-freetype=bundled",

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -43,10 +43,12 @@ project.configurations.compile.getFiles().each { depsMap[it.getName()] = it }
  * and we don't want to tamper with someone
  * else's tree.
  */
-task copySource(type: Copy) {
-    dependsOn project.configurations.compile
-    from tarTree(depsMap[sourceTar])
-    into buildRoot
+task copySource(type: Exec) {
+    if (!file(buildRoot).exists()) {
+        file(buildRoot).mkdirs()
+    }
+    workingDir '/usr/bin'
+    commandLine 'rsync', '-a', sourceDir, buildRoot
 }
 
 /** 
@@ -65,6 +67,7 @@ task applyPatches() {
 }
 
 task configureBuild(type: Exec) {
+    dependsOn project.configurations.compile
     dependsOn applyPatches
     workingDir "$buildRoot/src"
 

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -48,13 +48,16 @@ project.configurations.compile.getFiles().each { depsMap[it.getName()] = it }
  * and we don't want to tamper with someone
  * else's tree.
  */
-task copySource(type: Copy) {
-    dependsOn project.configurations.compile
-    from tarTree(depsMap[sourceTar])
-    into buildRoot
+task copySource(type: Exec) {
+    if (!file(buildRoot).exists()) {
+        file(buildRoot).mkdirs()
+    }
+    workingDir '/usr/bin'
+    commandLine 'rsync', '-a', sourceDir, buildRoot
 }
 
 task configureBuild(type: Exec) {
+    dependsOn project.configurations.compile
     dependsOn copySource
     workingDir "$buildRoot/src"
 


### PR DESCRIPTION
Utilize `rsync` for incremental build on linux & macOS.

One drawback of extracting the source from the source tar into the build directory is that Make is unable to only incrementally build modified files. This significantly slows down local development.

`rsync` the source from `$root/src` into the build dir also allows the source archiving task and the copy source task to run concurrently. 

### Test

On Linux:
```
./gradlew :installers:linux:universal:rpm:build
...
./gradlew :installers:linux:universal:deb:build
<Build artifacts of :installers:linux:universal:tar:build are reused>
```