### PR TITLE
Fix license files not included in corretto-11#106

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ allprojects {
         // artifact names
         caCerts = "cacerts"
         sourceTar = "amazon-corretto-source-${project.version.full}.tar.gz"
-        sourceDir = project(':openjdksrc').projectDir
 
         correttoCommonFlags = [
                 "--with-freetype=bundled",

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -48,7 +48,11 @@ task copySource(type: Exec) {
         file(buildRoot).mkdirs()
     }
     workingDir '/usr/bin'
-    commandLine 'rsync', '-a', sourceDir, buildRoot
+    commandLine 'rsync', '-am',
+            '--exclude=pre-build',
+            '--exclude=installers',
+            '--exclude=src/corretto-build',
+            "${project.rootDir}/", buildRoot
 }
 
 /** 

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -53,7 +53,11 @@ task copySource(type: Exec) {
         file(buildRoot).mkdirs()
     }
     workingDir '/usr/bin'
-    commandLine 'rsync', '-a', sourceDir, buildRoot
+    commandLine 'rsync', '-am',
+            '--exclude=pre-build',
+            '--exclude=installers',
+            '--exclude=src/corretto-build',
+            "${project.rootDir}/", buildRoot
 }
 
 task configureBuild(type: Exec) {


### PR DESCRIPTION
When introducing the incremental build in corretto-11#106, the license
and legal files are not copied to the buildRoot as expected.

### Test
On macOS, Run:
```
./gradlew :installers:mac:tar:copySource
```
* Before the fix
```
$ ls installers/mac/tar/corretto-build/buildRoot
src
$ ls installers/mac/tar/corretto-build/buildRoot/src/corretto-build
distributions
```

* After the fix
```
$ ls installers/mac/tar/corretto-build/buildRoot
ADDITIONAL_LICENSE_INFO LICENSE                 amazon-cacerts          version.txt
ASSEMBLY_EXCEPTION      README.md               src
$ ls installers/mac/tar/corretto-build/buildRoot/src/corretto-build
... No such file or directory
```