### PR TITLE
Backport JDK-8214545 from upstream

### DIFF
--- a/src/make/test/JtregNativeJdk.gmk
+++ b/src/make/test/JtregNativeJdk.gmk
@@ -62,9 +62,11 @@ ifeq ($(OPENJDK_TARGET_OS), windows)
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libstringPlatformChars := $(WIN_LIB_JAVA)
   WIN_LIB_JLI := $(SUPPORT_OUTPUTDIR)/native/java.base/libjli/jli.lib
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeJliLaunchTest := $(WIN_LIB_JLI)
+  BUILD_JDK_JTREG_EXECUTABLES_LIBS_exerevokeall := advapi32.lib
 else
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libstringPlatformChars := -ljava
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libDirectIO := -ljava
+  BUILD_JDK_JTREG_EXCLUDE += exerevokeall.c
   ifeq ($(OPENJDK_TARGET_OS), linux)
     BUILD_JDK_JTREG_LIBRARIES_LIBS_libInheritedChannel := -ljava
   else ifeq ($(OPENJDK_TARGET_OS), solaris)

--- a/src/test/jdk/sun/management/jmxremote/bootstrap/GeneratePropertyPassword.sh
+++ b/src/test/jdk/sun/management/jmxremote/bootstrap/GeneratePropertyPassword.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -69,13 +69,11 @@ EOF
     if [ "$OS" = "Windows_NT" ]; then
         USER=`id -u -n`
         CACLS="$SystemRoot/system32/cacls.exe"
-        TEST_SRC=`cygpath ${TESTSRC}`
-        REVOKEALL="$TEST_SRC/../../windows/revokeall.exe"
-        if [ ! -f "$REVOKEALL" ] ; then
-            echo "$REVOKEALL missing"
+        REVOKEALL="$TESTNATIVEPATH/revokeall.exe"
+        if [ ! -x "$REVOKEALL" ] ; then
+            echo "$REVOKEALL doesn't exist or is not executable"
             exit 1
         fi
-        chmod ug+x $REVOKEALL
     fi
     ;;
 *)

--- a/src/test/jdk/sun/management/windows/README
+++ b/src/test/jdk/sun/management/windows/README
@@ -1,6 +1,29 @@
+/*
+ * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 
-This directory contains the source and the binary version of a Windows 
-utility to remove all non-owner Access Control Entries from a given file.
+
+This directory contains the source of a Windows utility to remove all
+non-owner Access Control Entries from a given file.
 
 The tool is used by regression tests in the following directories :-
 
@@ -10,18 +33,3 @@ The tests in these directories create password or ACL files that need to
 be "secured" (meaning that only the owner should have access to the 
 files). 
 
-Both the source and the binary version are checked into SCCS. If
-you require to make changes to the tool then you need to Visual
-C++ to rebuild revokeall.exe after changing the source.
-
-To rebuild the tool you need to setup your environment (by
-calling the VC++ VCVARS32.BAT script), and then executing the 
-following command :-
-
-cl /mt revokeall.c advapi32.lib
-
-This will generate revokeall.exe.
-
-Note that a 32-bit version of revokeall.exe is checked into SCCS
-- this 32-bit application is also used when running on 64-bit
-versions of Windows (AMD64 and IA64).

--- a/src/test/jdk/sun/management/windows/exerevokeall.c
+++ b/src/test/jdk/sun/management/windows/exerevokeall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,7 @@
 #include <string.h>
 
 /*
- * Simple Windows utility to remove all non-owner access to a given
- * file - suitable for NT/2000/XP only.
+ * Simple Windows utility to remove all non-owner access to a given file.
  */
 
 
@@ -151,7 +150,7 @@ static char *getSIDString(SID* sid) {
     }
 
     if (LookupAccountSid(NULL, sid, name, &nameLen, domain, &domainLen, &use)) {
-        int len = strlen(name) + strlen(domain) + 3;
+        size_t len = strlen(name) + strlen(domain) + 3;
         char* s = (char*)malloc(len);
         if (s != NULL) {
             strcpy(s, domain);
@@ -352,6 +351,8 @@ static int revokeAll(const char* path) {
             return -1;
         }
         if (((ACCESS_ALLOWED_ACE *)ace)->Header.AceType != ACCESS_ALLOWED_ACE_TYPE) {
+            i++;
+            count--;
             continue;
         }
         access = (ACCESS_ALLOWED_ACE *)ace;


### PR DESCRIPTION
 JTreg Tier2 tests on Windows are hitting an infinite loop in revokeall.exe.
 Issue was fixed upstream and needed to be backported.

 https://bugs.openjdk.java.net/browse/JDK-8220581
 https://bugs.openjdk.java.net/browse/JDK-8214545

Thank you for taking the time to help improve OpenJDK and Corretto 11.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 11
and is not specific to Corretto 11,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 11,
then you are in the right place.
Please fill in the following information about your pull request.

### Description


### Related issues


### Motivation and context


### How has this been tested?


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "11.0.1+13-1" (see output from "java -version")]


### Additional context
