### PR TITLE
delete obsolete code

### DIFF
--- a/src/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -92,8 +92,8 @@ LIR_Opr LIRGenerator::result_register_for(ValueType* type, bool callee) {
     case intTag:     opr = FrameMap::rax_opr;          break;
     case objectTag:  opr = FrameMap::rax_oop_opr;      break;
     case longTag:    opr = FrameMap::long0_opr;        break;
-    case floatTag:   opr = UseSSE >= 1 ? FrameMap::xmm0_float_opr  : FrameMap::fpu0_float_opr;  break;
-    case doubleTag:  opr = UseSSE >= 2 ? FrameMap::xmm0_double_opr : FrameMap::fpu0_double_opr;  break;
+    case floatTag:   opr = FrameMap::xmm0_float_opr;   break;
+    case doubleTag:  opr = FrameMap::xmm0_double_opr;  break;
 
     case addressTag:
     default: ShouldNotReachHere(); return LIR_OprFact::illegalOpr;

--- a/src/src/hotspot/cpu/x86/c1_LinearScan_x86.hpp
+++ b/src/src/hotspot/cpu/x86/c1_LinearScan_x86.hpp
@@ -77,7 +77,7 @@ inline void LinearScan::pd_add_temps(LIR_Op* op) {
       // could also consider not killing all xmm registers if we
       // assume that slow paths are uncommon but it's not clear that
       // would be a good idea.
-      if (UseSSE > 0) {
+      //if (UseSSE > 0) {
 #ifndef PRODUCT
         if (TraceLinearScanLevel >= 2) {
           tty->print_cr("killing XMMs for trig");
@@ -89,7 +89,7 @@ inline void LinearScan::pd_add_temps(LIR_Op* op) {
           LIR_Opr opr = FrameMap::caller_save_xmm_reg_at(xmm);
           add_temp(reg_num(opr), op_id, noUse, T_ILLEGAL);
         }
-      }
+      //}
       break;
     }
     default:
@@ -112,7 +112,7 @@ inline bool LinearScanWalker::pd_init_regs_for_alloc(Interval* cur) {
     _first_reg = pd_first_byte_reg;
     _last_reg = FrameMap::last_byte_reg();
     return true;
-  } else if ((UseSSE >= 1 && cur->type() == T_FLOAT) || (UseSSE >= 2 && cur->type() == T_DOUBLE)) {
+  } else if (cur->type() == T_FLOAT || cur->type() == T_DOUBLE) {
     _first_reg = pd_first_xmm_reg;
     _last_reg = last_xmm_reg;
     return true;

--- a/src/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -325,9 +325,9 @@ void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_by
   }
 #ifdef TIERED
   // c2 leaves fpu stack dirty. Clean it on entry
-  if (UseSSE < 2 ) {
-    empty_FPU_stack();
-  }
+  //if (UseSSE < 2 ) {
+  //  empty_FPU_stack();
+  //}
 #endif // TIERED
   decrement(rsp, frame_size_in_bytes); // does not emit code for frame_size == 0
 }

--- a/src/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -366,44 +366,19 @@ static OopMap* generate_oop_map(StubAssembler* sasm, int num_rt_args,
 #endif
 
   if (save_fpu_registers) {
-    if (UseSSE < 2) {
-      int fpu_off = float_regs_as_doubles_off;
-      for (int n = 0; n < FrameMap::nof_fpu_regs; n++) {
-        VMReg fpu_name_0 = FrameMap::fpu_regname(n);
-        map->set_callee_saved(VMRegImpl::stack2reg(fpu_off +     num_rt_args), fpu_name_0);
-        // %%% This is really a waste but we'll keep things as they were for now
-        if (true) {
-          map->set_callee_saved(VMRegImpl::stack2reg(fpu_off + 1 + num_rt_args), fpu_name_0->next());
-        }
-        fpu_off += 2;
-      }
-      assert(fpu_off == fpu_state_off, "incorrect number of fpu stack slots");
-    }
-
-    if (UseSSE >= 2) {
-      int xmm_off = xmm_regs_as_doubles_off;
-      for (int n = 0; n < FrameMap::nof_xmm_regs; n++) {
-        if (n < xmm_bypass_limit) {
-          VMReg xmm_name_0 = as_XMMRegister(n)->as_VMReg();
-          map->set_callee_saved(VMRegImpl::stack2reg(xmm_off + num_rt_args), xmm_name_0);
-          // %%% This is really a waste but we'll keep things as they were for now
-          if (true) {
-            map->set_callee_saved(VMRegImpl::stack2reg(xmm_off + 1 + num_rt_args), xmm_name_0->next());
-          }
-        }
-        xmm_off += 2;
-      }
-      assert(xmm_off == float_regs_as_doubles_off, "incorrect number of xmm registers");
-
-    } else if (UseSSE == 1) {
-      int xmm_off = xmm_regs_as_doubles_off;
-      for (int n = 0; n < FrameMap::nof_fpu_regs; n++) {
+    int xmm_off = xmm_regs_as_doubles_off;
+    for (int n = 0; n < FrameMap::nof_xmm_regs; n++) {
+    if (n < xmm_bypass_limit) {
         VMReg xmm_name_0 = as_XMMRegister(n)->as_VMReg();
         map->set_callee_saved(VMRegImpl::stack2reg(xmm_off + num_rt_args), xmm_name_0);
-        xmm_off += 2;
-      }
-      assert(xmm_off == float_regs_as_doubles_off, "incorrect number of xmm registers");
+        // %%% This is really a waste but we'll keep things as they were for now
+        if (true) {
+            map->set_callee_saved(VMRegImpl::stack2reg(xmm_off + 1 + num_rt_args), xmm_name_0->next());
+        }
     }
+    xmm_off += 2;
+    }
+    assert(xmm_off == float_regs_as_doubles_off, "incorrect number of xmm registers");
   }
 
   return map;
@@ -700,9 +675,9 @@ OopMapSet* Runtime1::generate_handle_exception(StubID id, StubAssembler *sasm) {
 
 #ifdef TIERED
   // C2 can leave the fpu stack dirty
-  if (UseSSE < 2) {
-    __ empty_FPU_stack();
-  }
+  //if (UseSSE < 2) {
+  //  __ empty_FPU_stack();
+  //}
 #endif // TIERED
 
   // verify that only rax, and rdx is valid at this time

--- a/src/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -684,20 +684,8 @@ void InterpreterMacroAssembler::pop(TosState state) {
     case stos:                                               // fall through
     case itos: pop_i(rax);                                   break;
     case ltos: pop_l(rax, rdx);                              break;
-    case ftos:
-      if (UseSSE >= 1) {
-        pop_f(xmm0);
-      } else {
-        pop_f();
-      }
-      break;
-    case dtos:
-      if (UseSSE >= 2) {
-        pop_d(xmm0);
-      } else {
-        pop_d();
-      }
-      break;
+    case ftos: pop_f(xmm0);                                  break;
+    case dtos: pop_d(xmm0);                                  break;
     case vtos: /* nothing to do */                           break;
     default  : ShouldNotReachHere();
   }

--- a/src/src/hotspot/cpu/x86/methodHandles_x86.cpp
+++ b/src/src/hotspot/cpu/x86/methodHandles_x86.cpp
@@ -606,13 +606,8 @@ void MethodHandles::trace_method_handle(MacroAssembler* _masm, const char* adapt
 
   // save FP result, valid at some call sites (adapter_opt_return_float, ...)
   __ increment(rsp, -2 * wordSize);
-  if  (UseSSE >= 2) {
-    __ movdbl(Address(rsp, 0), xmm0);
-  } else if (UseSSE == 1) {
-    __ movflt(Address(rsp, 0), xmm0);
-  } else {
-    __ fst_d(Address(rsp, 0));
-  }
+  __ movdbl(Address(rsp, 0), xmm0);
+  
 
   // Incoming state:
   // rcx: method handle

--- a/src/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -196,19 +196,11 @@ OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, int additional_
 
   off = xmm0_off;
   delta = xmm1_off - off;
-  if(UseSSE == 1) {
-    // Save the XMM state
-    for (int n = 0; n < num_xmm_regs; n++) {
-      __ movflt(Address(rsp, off*wordSize), as_XMMRegister(n));
-      off += delta;
-    }
-  } else if(UseSSE >= 2) {
     // Save whole 128bit (16 bytes) XMM registers
     for (int n = 0; n < num_xmm_regs; n++) {
       __ movdqu(Address(rsp, off*wordSize), as_XMMRegister(n));
       off += delta;
     }
-  }
 
   if (save_vectors) {
     __ subptr(rsp, ymm_bytes);
@@ -537,11 +529,11 @@ static void patch_callers_callsite(MacroAssembler *masm) {
   }
 #ifdef COMPILER2
   // C2 may leave the stack dirty if not in SSE2+ mode
-  if (UseSSE >= 2) {
+  //if (UseSSE >= 2) {
     __ verify_FPU(0, "c2i transition should have clean FPU stack");
-  } else {
-    __ empty_FPU_stack();
-  }
+  //} else {
+  //  __ empty_FPU_stack();
+  //}
 #endif /* COMPILER2 */
 
   // VM needs caller's callsite
@@ -590,11 +582,11 @@ static void gen_c2i_adapter(MacroAssembler *masm,
 
 #ifdef COMPILER2
   // C2 may leave the stack dirty if not in SSE2+ mode
-  if (UseSSE >= 2) {
+  //if (UseSSE >= 2) {
     __ verify_FPU(0, "c2i transition should have clean FPU stack");
-  } else {
-    __ empty_FPU_stack();
-  }
+  //} else {
+  //  __ empty_FPU_stack();
+  //}
 #endif /* COMPILER2 */
 
   // Since all args are passed on the stack, total_args_passed * interpreter_

--- a/src/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -222,24 +222,9 @@ class StubGenerator: public StubCodeGenerator {
 #ifdef COMPILER2
     {
       Label L_skip;
-      if (UseSSE >= 2) {
-        __ verify_FPU(0, "call_stub_return");
-      } else {
-        for (int i = 1; i < 8; i++) {
-          __ ffree(i);
-        }
-
-        // UseSSE <= 1 so double result should be left on TOS
-        __ movl(rsi, result_type);
-        __ cmpl(rsi, T_DOUBLE);
-        __ jcc(Assembler::equal, L_skip);
-        if (UseSSE == 0) {
-          // UseSSE == 0 so float result should be left on TOS
-          __ cmpl(rsi, T_FLOAT);
-          __ jcc(Assembler::equal, L_skip);
-        }
-        __ ffree(0);
-      }
+    
+      __ verify_FPU(0, "call_stub_return");
+      
       __ BIND(L_skip);
     }
 #endif // COMPILER2

--- a/src/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -178,13 +178,13 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
 #ifndef _LP64
 #ifdef COMPILER2
   // The FPU stack is clean if UseSSE >= 2 but must be cleaned in other cases
-  if ((state == ftos && UseSSE < 1) || (state == dtos && UseSSE < 2)) {
-    for (int i = 1; i < 8; i++) {
-        __ ffree(i);
-    }
-  } else if (UseSSE < 2) {
-    __ empty_FPU_stack();
-  }
+  //if ((state == ftos && UseSSE < 1) || (state == dtos && UseSSE < 2)) {
+  //  for (int i = 1; i < 8; i++) {
+  //      __ ffree(i);
+  //  }
+  //} else if (UseSSE < 2) {
+  //  __ empty_FPU_stack();
+  //}
 #endif // COMPILER2
   if ((state == ftos && UseSSE < 1) || (state == dtos && UseSSE < 2)) {
     __ MacroAssembler::verify_FPU(1, "generate_return_entry_for compiled");

--- a/src/src/hotspot/cpu/x86/templateInterpreterGenerator_x86_32.cpp
+++ b/src/src/hotspot/cpu/x86/templateInterpreterGenerator_x86_32.cpp
@@ -209,7 +209,7 @@ address TemplateInterpreterGenerator::generate_CRC32C_updateBytes_entry(Abstract
  *    java.lang.Float.intBitsToFloat(int bits)
  */
 address TemplateInterpreterGenerator::generate_Float_intBitsToFloat_entry() {
-  if (UseSSE >= 1) {
+  //if (UseSSE >= 1) {
     address entry = __ pc();
 
     // rsi: the sender's SP
@@ -225,9 +225,9 @@ address TemplateInterpreterGenerator::generate_Float_intBitsToFloat_entry() {
     __ mov(rsp, rsi); // set rsp to the sender's SP
     __ jmp(rdi);
     return entry;
-  }
+  //}
 
-  return NULL;
+  //return NULL;
 }
 
 /**
@@ -235,7 +235,7 @@ address TemplateInterpreterGenerator::generate_Float_intBitsToFloat_entry() {
  *    java.lang.Float.floatToRawIntBits(float value)
  */
 address TemplateInterpreterGenerator::generate_Float_floatToRawIntBits_entry() {
-  if (UseSSE >= 1) {
+  //if (UseSSE >= 1) {
     address entry = __ pc();
 
     // rsi: the sender's SP
@@ -251,9 +251,9 @@ address TemplateInterpreterGenerator::generate_Float_floatToRawIntBits_entry() {
     __ mov(rsp, rsi); // set rsp to the sender's SP
     __ jmp(rdi);
     return entry;
-  }
+  //}
 
-  return NULL;
+  //return NULL;
 }
 
 

--- a/src/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -283,59 +283,36 @@ void TemplateTable::lconst(int value) {
 
 void TemplateTable::fconst(int value) {
   transition(vtos, ftos);
-  if (UseSSE >= 1) {
-    static float one = 1.0f, two = 2.0f;
-    switch (value) {
-    case 0:
-      __ xorps(xmm0, xmm0);
-      break;
-    case 1:
-      __ movflt(xmm0, ExternalAddress((address) &one));
-      break;
-    case 2:
-      __ movflt(xmm0, ExternalAddress((address) &two));
-      break;
-    default:
-      ShouldNotReachHere();
-      break;
-    }
-  } else {
-#ifdef _LP64
+  static float one = 1.0f, two = 2.0f;
+  switch (value) {
+  case 0:
+    __ xorps(xmm0, xmm0);
+    break;
+  case 1:
+    __ movflt(xmm0, ExternalAddress((address) &one));
+    break;
+  case 2:
+    __ movflt(xmm0, ExternalAddress((address) &two));
+    break;
+  default:
     ShouldNotReachHere();
-#else
-           if (value == 0) { __ fldz();
-    } else if (value == 1) { __ fld1();
-    } else if (value == 2) { __ fld1(); __ fld1(); __ faddp(); // should do a better solution here
-    } else                 { ShouldNotReachHere();
-    }
-#endif // _LP64
+    break;
   }
 }
 
 void TemplateTable::dconst(int value) {
   transition(vtos, dtos);
-  if (UseSSE >= 2) {
-    static double one = 1.0;
-    switch (value) {
-    case 0:
-      __ xorpd(xmm0, xmm0);
-      break;
-    case 1:
-      __ movdbl(xmm0, ExternalAddress((address) &one));
-      break;
-    default:
-      ShouldNotReachHere();
-      break;
-    }
-  } else {
-#ifdef _LP64
+  static double one = 1.0;
+  switch (value) {
+  case 0:
+    __ xorpd(xmm0, xmm0);
+    break;
+  case 1:
+    __ movdbl(xmm0, ExternalAddress((address) &one));
+    break;
+  default:
     ShouldNotReachHere();
-#else
-           if (value == 0) { __ fldz();
-    } else if (value == 1) { __ fld1();
-    } else                 { ShouldNotReachHere();
-    }
-#endif
+    break;
   }
 }
 

--- a/src/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/src/hotspot/cpu/x86/x86_64.ad
@@ -4281,67 +4281,67 @@ operand cmpOpUCF2() %{
 // Operands for bound floating pointer register arguments
 operand rxmm0() %{
   constraint(ALLOC_IN_RC(xmm0_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX<= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX<= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm1() %{
   constraint(ALLOC_IN_RC(xmm1_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm2() %{
   constraint(ALLOC_IN_RC(xmm2_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm3() %{
   constraint(ALLOC_IN_RC(xmm3_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm4() %{
   constraint(ALLOC_IN_RC(xmm4_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm5() %{
   constraint(ALLOC_IN_RC(xmm5_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm6() %{
   constraint(ALLOC_IN_RC(xmm6_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm7() %{
   constraint(ALLOC_IN_RC(xmm7_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm8() %{
   constraint(ALLOC_IN_RC(xmm8_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm9() %{
   constraint(ALLOC_IN_RC(xmm9_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm10() %{
   constraint(ALLOC_IN_RC(xmm10_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm11() %{
   constraint(ALLOC_IN_RC(xmm11_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm12() %{
   constraint(ALLOC_IN_RC(xmm12_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm13() %{
   constraint(ALLOC_IN_RC(xmm13_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm14() %{
   constraint(ALLOC_IN_RC(xmm14_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm15() %{
   constraint(ALLOC_IN_RC(xmm15_reg));  match(VecX);
-  predicate((UseSSE > 0) && (UseAVX <= 2));  format%{%}  interface(REG_INTER);
+  predicate(UseAVX <= 2);  format%{%}  interface(REG_INTER);
 %}
 operand rxmm16() %{
   constraint(ALLOC_IN_RC(xmm16_reg));  match(VecX);

--- a/src/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -482,14 +482,12 @@ void LIR_Assembler::emit_call(LIR_OpJavaCall* op) {
 
 #if defined(X86) && defined(TIERED)
   // C2 leave fpu stack dirty clean it
-  if (UseSSE < 2) {
-    int i;
-    for ( i = 1; i <= 7 ; i++ ) {
-      ffree(i);
-    }
-    if (!op->result_opr()->is_float_kind()) {
-      ffree(0);
-    }
+  int i;
+  for ( i = 1; i <= 7 ; i++ ) {
+    ffree(i);
+  }
+  if (!op->result_opr()->is_float_kind()) {
+    ffree(0);
   }
 #endif // X86 && TIERED
 }


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto 11.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 11
and is not specific to Corretto 11,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 11,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
Delete obsolete code because UseSSE is always >=2

### Related issues
Obsolete code will little bit lower the performance.

### Motivation and context


### How has this been tested?


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "11.0.1+13-1" (see output from "java -version")]


### Additional context
