### PR TITLE
delete the empty_FPU_stack

### DIFF
--- a/src/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -325,9 +325,6 @@ void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_by
   }
 #ifdef TIERED
   // c2 leaves fpu stack dirty. Clean it on entry
-  if (UseSSE < 2 ) {
-    empty_FPU_stack();
-  }
 #endif // TIERED
   decrement(rsp, frame_size_in_bytes); // does not emit code for frame_size == 0
 }

--- a/src/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -323,9 +323,7 @@ void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_by
   if (PreserveFramePointer) {
     mov(rbp, rsp);
   }
-#ifdef TIERED
-  // c2 leaves fpu stack dirty. Clean it on entry
-#endif // TIERED
+
   decrement(rsp, frame_size_in_bytes); // does not emit code for frame_size == 0
 }
 

--- a/src/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -698,10 +698,6 @@ OopMapSet* Runtime1::generate_handle_exception(StubID id, StubAssembler *sasm) {
   default:  ShouldNotReachHere();
   }
 
-#ifdef TIERED
-  // C2 can leave the fpu stack dirty
-#endif // TIERED
-
   // verify that only rax, and rdx is valid at this time
   __ invalidate_registers(false, true, true, false, true, true);
   // verify that rax, contains a valid exception

--- a/src/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -700,9 +700,6 @@ OopMapSet* Runtime1::generate_handle_exception(StubID id, StubAssembler *sasm) {
 
 #ifdef TIERED
   // C2 can leave the fpu stack dirty
-  if (UseSSE < 2) {
-    __ empty_FPU_stack();
-  }
 #endif // TIERED
 
   // verify that only rax, and rdx is valid at this time

--- a/src/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -539,8 +539,6 @@ static void patch_callers_callsite(MacroAssembler *masm) {
   // C2 may leave the stack dirty if not in SSE2+ mode
   if (UseSSE >= 2) {
     __ verify_FPU(0, "c2i transition should have clean FPU stack");
-  } else {
-    __ empty_FPU_stack();
   }
 #endif /* COMPILER2 */
 
@@ -592,8 +590,6 @@ static void gen_c2i_adapter(MacroAssembler *masm,
   // C2 may leave the stack dirty if not in SSE2+ mode
   if (UseSSE >= 2) {
     __ verify_FPU(0, "c2i transition should have clean FPU stack");
-  } else {
-    __ empty_FPU_stack();
   }
 #endif /* COMPILER2 */
 

--- a/src/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -182,8 +182,6 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
     for (int i = 1; i < 8; i++) {
         __ ffree(i);
     }
-  } else if (UseSSE < 2) {
-    __ empty_FPU_stack();
   }
 #endif // COMPILER2
   if ((state == ftos && UseSSE < 1) || (state == dtos && UseSSE < 2)) {


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto 11.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 11
and is not specific to Corretto 11,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 11,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
Delete empty_FPU_stack since useSSN is always larger or equal to 2.

### Related issues


### Motivation and context


### How has this been tested?
successfully build and run jtreg test.

### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "11.0.1+13-1" (see output from "java -version")]


### Additional context
