### PR TITLE
Change the parameter type inside function cast_to_instance_id into uint.

### DIFF
--- a/src/src/hotspot/share/opto/type.cpp
+++ b/src/src/hotspot/share/opto/type.cpp
@@ -3041,7 +3041,7 @@ const Type *TypeOopPtr::cast_to_ptr_type(PTR ptr) const {
 }
 
 //-----------------------------cast_to_instance_id----------------------------
-const TypeOopPtr *TypeOopPtr::cast_to_instance_id(int instance_id) const {
+const TypeOopPtr *TypeOopPtr::cast_to_instance_id(uint instance_id) const {
   // There are no instances of a general oop.
   // Return self unchanged.
   return this;
@@ -3544,8 +3544,8 @@ const Type *TypeInstPtr::cast_to_exactness(bool klass_is_exact) const {
 }
 
 //-----------------------------cast_to_instance_id----------------------------
-const TypeOopPtr *TypeInstPtr::cast_to_instance_id(int instance_id) const {
-  if( instance_id == _instance_id ) return this;
+const TypeOopPtr *TypeInstPtr::cast_to_instance_id(uint instance_id) const {
+  if( instance_id == (uint)_instance_id ) return this;
   return make(_ptr, klass(), _klass_is_exact, const_oop(), _offset, instance_id, _speculative, _inline_depth);
 }
 
@@ -4071,8 +4071,8 @@ const Type *TypeAryPtr::cast_to_exactness(bool klass_is_exact) const {
 }
 
 //-----------------------------cast_to_instance_id----------------------------
-const TypeOopPtr *TypeAryPtr::cast_to_instance_id(int instance_id) const {
-  if( instance_id == _instance_id ) return this;
+const TypeOopPtr *TypeAryPtr::cast_to_instance_id(uint instance_id) const {
+  if( instance_id == (uint)_instance_id ) return this;
   return make(_ptr, const_oop(), _ary, klass(), _klass_is_exact, _offset, instance_id, _speculative, _inline_depth);
 }
 

--- a/src/src/hotspot/share/opto/type.hpp
+++ b/src/src/hotspot/share/opto/type.hpp
@@ -1025,7 +1025,7 @@ public:
 
   virtual const Type *cast_to_exactness(bool klass_is_exact) const;
 
-  virtual const TypeOopPtr *cast_to_instance_id(int instance_id) const;
+  virtual const TypeOopPtr *cast_to_instance_id(uint instance_id) const;
 
   // corresponding pointer to klass, for a given instance
   const TypeKlassPtr* as_klass_type() const;
@@ -1107,7 +1107,7 @@ class TypeInstPtr : public TypeOopPtr {
 
   virtual const Type *cast_to_exactness(bool klass_is_exact) const;
 
-  virtual const TypeOopPtr *cast_to_instance_id(int instance_id) const;
+  virtual const TypeOopPtr *cast_to_instance_id(uint instance_id) const;
 
   virtual const TypePtr *add_offset( intptr_t offset ) const;
 
@@ -1190,7 +1190,7 @@ public:
 
   virtual const Type *cast_to_exactness(bool klass_is_exact) const;
 
-  virtual const TypeOopPtr *cast_to_instance_id(int instance_id) const;
+  virtual const TypeOopPtr *cast_to_instance_id(uint instance_id) const;
 
   virtual const TypeAryPtr* cast_to_size(const TypeInt* size) const;
   virtual const TypeInt* narrow_size_type(const TypeInt* size) const;


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto 11.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 11
and is not specific to Corretto 11,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 11,
then you are in the right place.
Please fill in the following information about your pull request.

### Description

Node::_idx is declared as node_idx_t (unsigned int) but at several places we cast it to int. For example, in escape.cpp: 
uint ni = n->_idx; 
[...] 
const TypeOopPtr* tinst = t->cast_to_instance_id(ni); 
with TypeOopPtr::cast_to_instance_id(int instance_id). This should be fixed to use unsigned int consistently.

### Related issues


### Motivation and context


### How has this been tested?
Run jtreg test and no failed.

### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "11.0.1+13-1" (see output from "java -version")]


### Additional context
