### PR TITLE
Set legal directory file permissions.

### DIFF
--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -126,6 +126,14 @@ task generateJdkRpm(type: Rpm) {
 
     from(jdkBinaryDir) {
         into jdkHome
+        exclude 'legal'
+    }
+
+    // Copy legal directory specifically to set permission correctly.
+    // See https://github.com/corretto/corretto-11/issues/129
+    from("${jdkBinaryDir}/legal") {
+        into "${jdkHome}/legal"
+        fileMode 0444
     }
 }
 


### PR DESCRIPTION
Legal directory is make from symlinks which don't preserve the file permissions.
Exclude legal from the bulk file copy and add with correct fileMode to ensure
files are not executable or writable.

