### PR TITLE
8222518: Remove unnecessary caching of Parker object in java.lang.Thread

### DIFF
--- a/src/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/src/hotspot/share/classfile/javaClasses.cpp
@@ -1605,7 +1605,6 @@ int java_lang_Thread::_stackSize_offset = 0;
 int java_lang_Thread::_tid_offset = 0;
 int java_lang_Thread::_thread_status_offset = 0;
 int java_lang_Thread::_park_blocker_offset = 0;
-int java_lang_Thread::_park_event_offset = 0 ;
 
 #define THREAD_FIELDS_DO(macro) \
   macro(_name_offset,          k, vmSymbols::name_name(), string_signature, false); \
@@ -1619,8 +1618,7 @@ int java_lang_Thread::_park_event_offset = 0 ;
   macro(_stackSize_offset,     k, "stackSize", long_signature, false); \
   macro(_tid_offset,           k, "tid", long_signature, false); \
   macro(_thread_status_offset, k, "threadStatus", int_signature, false); \
-  macro(_park_blocker_offset,  k, "parkBlocker", object_signature, false); \
-  macro(_park_event_offset,    k, "nativeParkEventPointer", long_signature, false)
+  macro(_park_blocker_offset,  k, "parkBlocker", object_signature, false)
 
 void java_lang_Thread::compute_offsets() {
   assert(_group_offset == 0, "offsets should be initialized only once");
@@ -1766,22 +1764,6 @@ oop java_lang_Thread::park_blocker(oop java_thread) {
 
   return NULL;
 }
-
-jlong java_lang_Thread::park_event(oop java_thread) {
-  if (_park_event_offset > 0) {
-    return java_thread->long_field(_park_event_offset);
-  }
-  return 0;
-}
-
-bool java_lang_Thread::set_park_event(oop java_thread, jlong ptr) {
-  if (_park_event_offset > 0) {
-    java_thread->long_field_put(_park_event_offset, ptr);
-    return true;
-  }
-  return false;
-}
-
 
 const char* java_lang_Thread::thread_status_name(oop java_thread) {
   assert(_thread_status_offset != 0, "Must have thread status");

--- a/src/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/src/hotspot/share/classfile/javaClasses.hpp
@@ -360,7 +360,6 @@ class java_lang_Thread : AllStatic {
   static int _tid_offset;
   static int _thread_status_offset;
   static int _park_blocker_offset;
-  static int _park_event_offset ;
 
   static void compute_offsets();
 
@@ -401,12 +400,6 @@ class java_lang_Thread : AllStatic {
 
   // Blocker object responsible for thread parking
   static oop park_blocker(oop java_thread);
-
-  // Pointer to type-stable park handler, encoded as jlong.
-  // Should be set when apparently null
-  // For details, see unsafe.cpp Unsafe_Unpark
-  static jlong park_event(oop java_thread);
-  static bool set_park_event(oop java_thread, jlong ptr);
 
   // Java Thread Status for JVMTI and M&M use.
   // This thread status info is saved in threadStatus field of

--- a/src/src/hotspot/share/prims/unsafe.cpp
+++ b/src/src/hotspot/share/prims/unsafe.cpp
@@ -967,27 +967,16 @@ UNSAFE_ENTRY(void, Unsafe_Unpark(JNIEnv *env, jobject unsafe, jobject jthread)) 
     (void) tlh.cv_internal_thread_to_JavaThread(jthread, &thr, &java_thread);
     if (java_thread != NULL) {
       // This is a valid oop.
-      jlong lp = java_lang_Thread::park_event(java_thread);
-      if (lp != 0) {
-        // This cast is OK even though the jlong might have been read
-        // non-atomically on 32bit systems, since there, one word will
-        // always be zero anyway and the value set is always the same
-        p = (Parker*)addr_from_java(lp);
-      } else {
-        // Not cached in the java.lang.Thread oop yet (could be an
-        // older version of library).
-        if (thr != NULL) {
-          // The JavaThread is alive.
-          p = thr->parker();
-          if (p != NULL) {
-            // Cache the Parker in the java.lang.Thread oop for next time.
-            java_lang_Thread::set_park_event(java_thread, addr_to_java(p));
-          }
-        }
+      if (thr != NULL) {
+        // The JavaThread is alive.
+        p = thr->parker();
       }
     }
   } // ThreadsListHandle is destroyed here.
 
+  // 'p' points to type-stable-memory if non-NULL. If the target
+  // thread terminates before we get here the new user of this
+  // Parker will get a 'spurious' unpark - which is perfectly valid.
   if (p != NULL) {
     HOTSPOT_THREAD_UNPARK((uintptr_t) p);
     p->unpark();

--- a/src/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/src/java.base/share/classes/java/lang/Thread.java
@@ -193,11 +193,6 @@ class Thread implements Runnable {
     private final long stackSize;
 
     /*
-     * JVM-private state that persists after native thread termination.
-     */
-    private long nativeParkEventPointer;
-
-    /*
      * Thread ID
      */
     private final long tid;


### PR DESCRIPTION
Reviewed-by: dcubed, rehn

https://bugs.openjdk.java.net/browse/JDK-8222518
http://hg.openjdk.java.net/jdk/jdk/rev/9ebb614d293d

Applies cleanly

Thank you for taking the time to help improve OpenJDK and Corretto 11.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 11
and is not specific to Corretto 11,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 11,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
Part of the September ARM Patches set

### Related issues
Backport applies cleanly

### Motivation and context


### How has this been tested?
tier1 and tier 2 on arm64 and x86

### Platform information
    Works on OS: AL2
    Applies to version [e.g. "11.0.1+13-1" (see output from "java -version")]


### Additional context
