### PR TITLE
8229351: AArch64: the const STUB_THRESHOLD in macroAssembler_aarch64.…

### DIFF
--- a/src/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -4092,6 +4092,7 @@ class StubGenerator: public StubCodeGenerator {
     __ bind(NO_PREFETCH);
     __ subs(cnt2, cnt2, 16);
     __ br(__ LT, TAIL);
+    __ align(OptoLoopAlignment);
     __ bind(SMALL_LOOP); // smaller loop
       __ subs(cnt2, cnt2, 16);
       compare_string_16_x_LU(tmpL, tmpU, DIFF1, DIFF2);
@@ -4181,6 +4182,7 @@ class StubGenerator: public StubCodeGenerator {
     // less than 16 bytes left?
     __ subs(cnt2, cnt2, isLL ? 16 : 8);
     __ br(__ LT, TAIL);
+    __ align(OptoLoopAlignment);
     __ bind(SMALL_LOOP);
       compare_string_16_bytes_same(DIFF, DIFF2);
       __ subs(cnt2, cnt2, isLL ? 16 : 8);

--- a/src/test/hotspot/jtreg/compiler/intrinsics/string/TestStringCompareToDifferentLength.java
+++ b/src/test/hotspot/jtreg/compiler/intrinsics/string/TestStringCompareToDifferentLength.java
@@ -32,12 +32,12 @@
  *          parameters: <string length>, <maximum string length delta>
  *          Input parameters for this test are set according to Aarch64
  *          String::compareTo intrinsic implementation specifics. Aarch64
- *          implementation has 1, 4, 8 -characters loops for length < 72 and
+ *          implementation has 1, 4, 8 -bytes loops for length < 72 and
  *          16, 32, 64 -characters loops for length >= 72. Code is also affected
  *          by SoftwarePrefetchHintDistance vm flag value.
- * @run main/othervm -XX:SoftwarePrefetchHintDistance=192 compiler.intrinsics.string.TestStringCompareToDifferentLength 4 2 5 10 13 17 20 25 71 72 73 88 90 192 193 208 209
- * @run main/othervm -XX:SoftwarePrefetchHintDistance=16 compiler.intrinsics.string.TestStringCompareToDifferentLength 4 2 5 10 13 17 20 25 71 72 73 88 90
- * @run main/othervm -XX:SoftwarePrefetchHintDistance=-1 compiler.intrinsics.string.TestStringCompareToDifferentLength 4 2 5 10 13 17 20 25 71 72 73 88 90
+ * @run main/othervm -XX:SoftwarePrefetchHintDistance=192 compiler.intrinsics.string.TestStringCompareToDifferentLength 4 2 5 10 13 17 20 23 24 25 71 72 73 88 90 192 193 208 209
+ * @run main/othervm -XX:SoftwarePrefetchHintDistance=16 compiler.intrinsics.string.TestStringCompareToDifferentLength 4 2 5 10 13 17 20 23 24 25 71 72 73 88 90
+ * @run main/othervm -XX:SoftwarePrefetchHintDistance=-1 compiler.intrinsics.string.TestStringCompareToDifferentLength 4 2 5 10 13 17 20 23 24 25 71 72 73 88 90
  */
 
 package compiler.intrinsics.string;

--- a/src/test/hotspot/jtreg/compiler/intrinsics/string/TestStringCompareToSameLength.java
+++ b/src/test/hotspot/jtreg/compiler/intrinsics/string/TestStringCompareToSameLength.java
@@ -32,16 +32,16 @@
  *          String size is specified via commandline. Various size values can
  *          be specified during intrinsic development in order to test cases
  *          specific for new or modified intrinsic implementation. Aarch64
- *          implementation has 1, 4, 8 -characters loops for length < 72 and
- *          16, 32, 64 -characters loops for string length >= 72. Code is also
+ *          implementation has 1, 4, 8 -bytes loops for length < 72 and
+ *          16, 32, 64 -bytes loops for string length >= 72. Code is also
  *          affected by SoftwarePrefetchHintDistance flag value.
  *          Test class can also accept "-fullmode" parameter
  *          with maxLength paramter after it. Then it will iterate through all
  *          string length values up to maxLength parameter (inclusive). It takes
  *          a lot of time but is useful for development.
- * @run main/othervm -XX:SoftwarePrefetchHintDistance=192 compiler.intrinsics.string.TestStringCompareToSameLength 2 5 10 13 17 20 25 71 72 73 88 90 192 193 208 209
- * @run main/othervm -XX:SoftwarePrefetchHintDistance=16 compiler.intrinsics.string.TestStringCompareToSameLength 2 5 10 13 17 20 25 71 72 73 88 90
- * @run main/othervm -XX:SoftwarePrefetchHintDistance=-1 compiler.intrinsics.string.TestStringCompareToSameLength 2 5 10 13 17 20 25 71 72 73 88 90
+ * @run main/othervm -XX:SoftwarePrefetchHintDistance=192 compiler.intrinsics.string.TestStringCompareToSameLength 2 5 10 13 17 20 25 35 36 37 71 72 73 88 90 192 193 208 209
+ * @run main/othervm -XX:SoftwarePrefetchHintDistance=16 compiler.intrinsics.string.TestStringCompareToSameLength 2 5 10 13 17 20 25 35 36 37 71 72 73 88 90
+ * @run main/othervm -XX:SoftwarePrefetchHintDistance=-1 compiler.intrinsics.string.TestStringCompareToSameLength 2 5 10 13 17 20 25 35 36 37 71 72 73 88 90
  */
 
 package compiler.intrinsics.string;


### PR DESCRIPTION
…cpp needs to be tuned

Summary: Optimize the stub thresholds of string_compare intrinsics
Reviewed-by: adinn, aph, avoitylov

https://bugs.openjdk.java.net/browse/JDK-8229351
https://hg.openjdk.java.net/jdk/jdk/rev/10ca494c141f

Applies cleanly

Thank you for taking the time to help improve OpenJDK and Corretto 11.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 11
and is not specific to Corretto 11,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 11,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
Part of the September ARM Patches set

### Related issues
Backport applies cleanly

### Motivation and context


### How has this been tested?
tier1 and tier 2 on arm64 and x86

### Platform information
    Works on OS: AL2
    Applies to version [e.g. "11.0.1+13-1" (see output from "java -version")]


### Additional context
