### PR TITLE
Move files in root of tar.gz to subfolder

### DIFF
--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -130,6 +130,7 @@ task packageBuildResults(type: Tar) {
         include 'LICENSE'
         include 'README.md'
         include 'version.txt'
+        into project.correttoJdkArchiveName
     }
     from(jdkResultingImage) {
         include 'bin/**'


### PR DESCRIPTION
Resolves the issue in https://github.com/corretto/corretto-11/issues/145.

Testing done:
Built locally and extracted the tar.gz, all files are in the amazon-corretto-<version> folder.