### PR TITLE
Add build logic of generic Linux armv7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,12 +86,18 @@ allprojects {
         }
 
         is_x86 = false
+        is_armv7 = false
         if (project.hasProperty("x86")) {
             is_x86 = Boolean.valueOf("${project.getProperty('x86')}")
         }
+        if (project.hasProperty("armv7")) {
+            is_armv7 = Boolean.valueOf("${project.getProperty('armv7')}")
+        }
         if (is_x86) {
             correttoCommonFlags += ["--with-target-bits=32"]
-        } else {
+        } else if (!is_armv7) {
+            // ARMV7 is built from cross-platform compilation with '--openjdk-target'
+            // flag, which is in conflict with '--with-target-bits'.
             correttoCommonFlags += ["--with-target-bits=64"]
         }
 
@@ -141,8 +147,10 @@ allprojects {
             jdkArch = ['uname', '-m'].execute().text.trim()
             // `uname -m` returns the host arch in a linux x86 docker instance. Pass a flag
             // to enable
-            if (project.hasProperty("x86") && Boolean.parseBoolean(project.getProperty('x86'))) {
+            if (is_x86) {
                 jdkArch = "x86"
+            } else if (is_armv7) {
+                jdkArch = "armv7"
             }
         } else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             os = 'windows'
@@ -164,6 +172,10 @@ allprojects {
                 break
             case 'x86_64':
                 correttoArch = 'x64'
+                break
+            case 'armv7':
+                correttoArch = jdkArch
+                jdkArch = 'arm'
                 break
             default:
                 throw new GradleException("${jdkArch} is not supported")

--- a/installers/linux/universal/deb/build.gradle
+++ b/installers/linux/universal/deb/build.gradle
@@ -31,12 +31,15 @@ ext {
     switch (project.correttoArch) {
         case 'aarch64':
             arch_deb = 'arm64'
-            break;
+            break
         case 'x86':
             arch_deb = "i386"
             break
         case 'x64':
             arch_deb = 'amd64'
+            break
+        case 'armv7':
+            arch_deb = 'armhf'
             break
     }
 }

--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -31,12 +31,15 @@ ext {
     switch (project.correttoArch) {
         case 'aarch64':
             arch_redline = 'AARCH64'
-            break;
+            break
         case 'x86':
             arch_redline = "i386"
             break
         case 'x64':
             arch_redline = 'x86_64'
+            break
+        case 'armv7':
+            arch_redline = 'ARM'
             break
     }
 }

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -35,6 +35,14 @@ if (project.correttoArch == 'aarch64') {
             '--with-extra-cxxflags=-moutline-atomics'
         ]
 }
+if (project.correttoArch == 'armv7') {
+    archSpecificFlags += [
+            '--with-sysroot=/opt/sysroot/',
+            '--with-toolchain-path=/opt/sysroot/',
+            '--openjdk-target=arm-linux-gnueabihf',
+            '--disable-warnings-as-errors'
+        ]
+}
 
 def imageDir= "$buildRoot/src/build/${project.jdkImageName}/images"
 def jdkResultingImage = "${imageDir}/jdk"


### PR DESCRIPTION
### Description
Update Gradle logic to support Corretto 11 build on generic Linux armv7.


### How has this been tested?
- Cross-compiled Corretto 11 binary

```
openjdk version "11.0.9" 2020-10-20 LTS
OpenJDK Runtime Environment Corretto-11.0.9.11.2 (build 11.0.9+11-LTS)
OpenJDK Server VM Corretto-11.0.9.11.2 (build 11.0.9+11-LTS, mixed mode)
```

- Jtreg tier 1; Jtreg tier 2; TCK

### Platform information
    Works on OS: [e.g. Linux armv7 or above, with glibc 2.25 or above]

