### PR TITLE
Set default target 'build' for mac and windows

### DIFF
--- a/installers/mac/pkg/build.gradle
+++ b/installers/mac/pkg/build.gradle
@@ -84,6 +84,8 @@ task generateInstaller {
     }
 }
 
+build.dependsOn generateInstaller
+
 artifacts {
     archives file: generateInstaller.outputs.getFiles().getSingleFile(), builtBy: generateInstaller
 }

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -158,6 +158,9 @@ task packageTestResults(type: Tar) {
 
 }
 
+build.dependsOn packaging
+build.dependsOn packageTestResults
+
 artifacts {
     buildTar file: packaging.outputs.getFiles().getSingleFile(), builtBy: packaging
     testLib packageTestResults

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -85,6 +85,8 @@ task packageJdk(type: Zip) {
     }
 }
 
+build.dependsOn packageJdk
+
 artifacts {
     archives packageJdk
 }


### PR DESCRIPTION
`build` is the default target for any Gradle module. It is missing in mac tar, mac pkg modules and windows zip modules. Developers who want to build mac or windows have to find out the specific task from the gradle script, which is inconvenient. This small change addresses the issue. After this change, to build mac & windows:
```
# Build both test image and artifacts
./gradlew ... :installers:mac:tar:build
# Build installer
./gradlew ... :installers:mac:pkg:build
# Build zip
./gradlew ... :installers:windows:zip:build
```