### PR TITLE
Update Alpine flags to include Shenandoah and VM bug URL

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -80,7 +80,7 @@ task configureBuild(type: Exec) {
     def configureCmd = [
         'bash',
         'configure',
-        '--with-jvm-features=zgc',
+        '--with-jvm-features=zgc shenandoahgc',
         "--with-version-feature=${version.major}",
         '--with-freetype=bundled',
         '--with-zlib=bundled',
@@ -91,6 +91,7 @@ task configureBuild(type: Exec) {
         '--with-vendor-name=Amazon.com Inc.',
         '--with-vendor-url=https://aws.amazon.com/corretto/',
         "--with-vendor-bug-url=https://github.com/corretto/corretto-${version.major}/issues/",
+        "--with-vendor-vm-bug-url=https://github.com/corretto/corretto-${version.major}/issues/",
         '--with-debug-level=release',
         '--with-native-debug-symbols=none',
         '--with-stdc++lib=static',


### PR DESCRIPTION

Updating flags to match other platforms.

## Testing done
Local build and tested ShenandoahGC was available.