### PR TITLE
Use 'isb' instruction in SpinPause and intrinsic _onSpinWait for AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2042,8 +2042,10 @@ int HandlerImpl::emit_deopt_handler(CodeBuffer& cbuf)
 const bool Matcher::match_rule_supported(int opcode) {
 
   switch (opcode) {
-  default:
-    break;
+    case Op_OnSpinWait:
+      return VM_Version::supports_on_spin_wait();
+    default:
+      break;
   }
 
   if (!has_match_rule(opcode)) {
@@ -3363,6 +3365,7 @@ encode %{
     Label cont;
     Label object_has_monitor;
     Label cas_failed;
+    Label monitor_fallthrough;
 
     assert_different_registers(oop, box, tmp, disp_hdr);
 
@@ -3393,6 +3396,10 @@ encode %{
     // Compare object markOop with an unlocked value (tmp) and if
     // equal exchange the stack address of our box with object markOop.
     // On failure disp_hdr contains the possibly locked markOop.
+    __ cmpxchg(oop, tmp, box, Assembler::xword, /*acquire*/ true,
+               /*release*/ true, /*weak*/ false, disp_hdr);
+    __ br(Assembler::EQ, cont);
+    __ isb();
     __ cmpxchg(oop, tmp, box, Assembler::xword, /*acquire*/ true,
                /*release*/ true, /*weak*/ false, disp_hdr);
     __ br(Assembler::EQ, cont);
@@ -3427,6 +3434,12 @@ encode %{
       __ add(tmp, disp_hdr, (ObjectMonitor::owner_offset_in_bytes()-markOopDesc::monitor_value));
     __ cmpxchg(tmp, zr, rthread, Assembler::xword, /*acquire*/ true,
                /*release*/ true, /*weak*/ false, noreg); // Sets flags for result
+    __ br(Assembler::EQ, monitor_fallthrough);
+    __ isb();
+    __ cmpxchg(tmp, zr, rthread, Assembler::xword, /*acquire*/ true,
+               /*release*/ true, /*weak*/ false, noreg); // Sets flags for result
+
+    __ bind(monitor_fallthrough);
 
       // Store a non-null value into the box to avoid looking like a re-entrant
       // lock. The fast-path monitor unlock code checks for
@@ -12728,6 +12741,24 @@ instruct signumF_reg(vRegF dst, vRegF src, vRegF zero, vRegF one) %{
     __ bsl(dst, __ T8B, one, src);
   %}
   ins_pipe(fp_uop_d);
+%}
+
+instruct onspinwait() %{
+  match(OnSpinWait);
+  ins_cost(INSN_COST);
+
+  format %{
+    $$template
+    if (os::is_MP()) {
+      $$emit$$"'ISB\t! membar_onspinwait"
+    } else {
+      $$emit$$"MEMBAR-onspinwait ! (empty encoding)"
+    }
+  %}
+  ins_encode %{
+    __ isb();
+  %}
+  ins_pipe(pipe_class_empty);
 %}
 
 // ============================================================================

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -3004,9 +3004,7 @@ void LIR_Assembler::membar_loadstore() { __ membar(MacroAssembler::LoadStore); }
 
 void LIR_Assembler::membar_storeload() { __ membar(MacroAssembler::StoreLoad); }
 
-void LIR_Assembler::on_spin_wait() {
-  Unimplemented();
-}
+void LIR_Assembler::on_spin_wait() { __ isb(); }
 
 void LIR_Assembler::get_thread(LIR_Opr result_reg) {
   __ mov(result_reg->as_register(), rthread);

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -119,6 +119,7 @@ public:
   static int dcache_line_size() {
     return (1 << ((_psr_info.ctr_el0 >> 16) & 0x0f)) * 4;
   }
+  static bool supports_on_spin_wait() { return true; }
 };
 
 #endif // CPU_AARCH64_VM_VM_VERSION_AARCH64_HPP

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -548,6 +548,7 @@ int os::extra_bang_size_in_bytes() {
 
 extern "C" {
   int SpinPause() {
+    __asm volatile("isb");
     return 0;
   }
 

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWait.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWait.java
@@ -28,7 +28,7 @@
  * @bug 8147844
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @requires os.arch=="x86" | os.arch=="amd64" | os.arch=="x86_64"
+ * @requires os.arch=="x86" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
  * @run driver compiler.onSpinWait.TestOnSpinWait
  */
 


### PR DESCRIPTION
### Description

This PR combines patches for the following JBS issues:
- [8186670](https://bugs.openjdk.java.net/browse/JDK-8258604): Implement _onSpinWait() intrinsic for AArch64
- [8258604](https://bugs.openjdk.java.net/browse/JDK-8186670): Use 'isb' instruction in SpinPause on linux-aarch64

### Motivation and context

Performance data for Neoverse N1 shows that `isb` can be used to simulate the x86 `pause`. It is more reliable than `yield` or a sequence of `nop`.

### How has this been tested?

Tested: Amazon Linux 2 AArch64, gtest, tier1, tier2, hotspot/jtreg/compiler/onSpinWait/TestOnSpinWait.java

### Platform information
    Works on OS: Linux AArch64
    Applies to version: 11.0.12
