### PR TITLE
Fix build issue in windows caused by GCC 10 patches

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntimeTrig.cpp
+++ b/src/hotspot/share/runtime/sharedRuntimeTrig.cpp
@@ -175,7 +175,7 @@ twon24  = 5.96046447753906250000e-08; /* 0x3E700000, 0x00000000 */
 
 static int __kernel_rem_pio2(double *x, double *y, int e0, int nx, int prec, const int *ipio2) {
   int jz,jx,jv,jp,jk,carry,n,iq[20],i,j,k,m,q0,ih;
-  double z,fw,f[20],fq[20] = {0.0d} ,q[20];
+  double z,fw,f[20],fq[20] = {0.0} ,q[20];
 
   /* initialize jk*/
   jk = init_jk[prec];


### PR DESCRIPTION
Although gcc recognizes 0.0d as a floating point double literal, according to https://en.cppreference.com/w/cpp/language/floating_literal no suffix should be used for double. This is causing Windows builds to fail with:
```
./src/hotspot/share/runtime/sharedRuntimeTrig.cpp(178): error C3688: invalid literal suffix 'd'; literal operator or literal operator template 'operator ""d' not found
```