### PR TITLE
8186670: Implement _onSpinWait() intrinsic for AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -12727,6 +12727,24 @@ instruct signumF_reg(vRegF dst, vRegF src, vRegF zero, vRegF one) %{
   ins_pipe(fp_uop_d);
 %}
 
+instruct onspinwait() %{
+  match(OnSpinWait);
+  ins_cost(INSN_COST);
+
+  format %{
+    $$template
+    if (os::is_MP()) {
+      $$emit$$"'ISB\t! membar_onspinwait"
+    } else {
+      $$emit$$"MEMBAR-onspinwait ! (empty encoding)"
+    }
+  %}
+  ins_encode %{
+    __ isb();
+  %}
+  ins_pipe(pipe_class_empty);
+%}
+
 // ============================================================================
 // Logical Instructions
 

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -3004,9 +3004,7 @@ void LIR_Assembler::membar_loadstore() { __ membar(MacroAssembler::LoadStore); }
 
 void LIR_Assembler::membar_storeload() { __ membar(MacroAssembler::StoreLoad); }
 
-void LIR_Assembler::on_spin_wait() {
-  Unimplemented();
-}
+void LIR_Assembler::on_spin_wait() { __ isb(); }
 
 void LIR_Assembler::get_thread(LIR_Opr result_reg) {
   __ mov(result_reg->as_register(), rthread);

--- a/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWait.java
+++ b/test/hotspot/jtreg/compiler/onSpinWait/TestOnSpinWait.java
@@ -28,7 +28,7 @@
  * @bug 8147844
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @requires os.arch=="x86" | os.arch=="amd64" | os.arch=="x86_64"
+ * @requires os.arch=="x86" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
  * @run driver compiler.onSpinWait.TestOnSpinWait
  */
 


### PR DESCRIPTION
### Description

This PR includes a patch for the following JBS issue:
- [8186670](https://bugs.openjdk.java.net/browse/JDK-8258604): Implement _onSpinWait() intrinsic for AArch64

### Motivation and context

Performance data for Neoverse N1 shows that `isb` can be used to simulate the x86 `pause`. It is more reliable than `yield` or a sequence of `nop`.

### How has this been tested?

Tested: Amazon Linux 2 AArch64, gtest, tier1, tier2, hotspot/jtreg/compiler/onSpinWait/TestOnSpinWait.java

### Platform information
    Works on OS: Linux AArch64
    Applies to version: 11.0.12