### PR TITLE
8258604: Use 'isb' instruction in SpinPause on linux-aarch64

### DIFF
--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -548,6 +548,7 @@ int os::extra_bang_size_in_bytes() {
 
 extern "C" {
   int SpinPause() {
+    __asm volatile("isb");
     return 0;
   }
 


### PR DESCRIPTION
### Description

This PR includes a patch for the following JBS issue:
- [8258604](https://bugs.openjdk.java.net/browse/JDK-8186670): Use 'isb' instruction in SpinPause on linux-aarch64

### Motivation and context

Performance data for Neoverse N1 shows that `isb` can be used to simulate the x86 `pause`. It is more reliable than `yield` or a sequence of `nop`.

### How has this been tested?

Tested: Amazon Linux 2 AArch64, gtest, tier1, tier2

### Platform information
    Works on OS: Linux AArch64
    Applies to version: 11.0.12
