### PR TITLE
Backport 3586a233a49c979e87fed9df148d0bf3df2df38b

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -854,6 +854,7 @@ void ClassLoaderData::init_handle_locked(OopHandle& dest, Handle h) {
   if (dest.resolve() != NULL) {
     return;
   } else {
+    record_modified_oops();
     dest = _handles.add(h());
   }
 }


### PR DESCRIPTION
This pull request contains a backport of commit 3586a233 from the openjdk/jdk repository.

The commit being backported was authored by Coleen Phillimore on 7 Jul 2021 and was reviewed by Ioi Lam and David Holmes. This fixes a crash during garbage collection caused in some cases when class loading fails to dirty the class loader data.

Thanks!