### PR TITLE
Debug zipped

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ allprojects {
         switch(project.findProperty("corretto.debug_level")) {
             case null:
             case "release":
-                correttoCommonFlags += ['--with-debug-level=release', '--with-native-debug-symbols=none']
+                correttoCommonFlags += ['--with-debug-level=release', '--with-native-debug-symbols=zipped']
                 break
             case "fastdebug":
                 correttoDebugLevel = "fastdebug"
@@ -191,6 +191,7 @@ allprojects {
             correttoJdkArchiveName =
                     "amazon-corretto-${project.version.full}-${os}-${correttoArch}-${correttoDebugLevel}".toString()
         }
+        correttoDebugSymbolsArchiveName = "amazon-corretto-debugsymbols-${project.version.full}-${os}-${correttoArch}".toString()
         correttoTestImageArchiveName = "amazon-corretto-testimage-${project.version.full}-${os}-${correttoArch}".toString()
     }
 }

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -143,9 +143,21 @@ task packageTestImage(type: Tar) {
 
 }
 
+task packageDebugSymbols(type: Tar) {
+    dependsOn packageTestImage
+    description 'Package debug symbols'
+    archiveName "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
+    compression Compression.GZIP
+    from(jdkResultingImage) {
+        include 'bin/*.diz'
+        include 'lib/*.diz'
+    }
+    into "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}"
+}
+
 task packageBuildResults(type: Tar) {
     description 'Compresses the JDK image and puts the results in build/distributions.'
-    dependsOn packageTestImage
+    dependsOn packageDebugSymbols
     dependsOn importAmazonCacerts
     archiveName "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
     compression Compression.GZIP
@@ -166,6 +178,7 @@ task packageBuildResults(type: Tar) {
         include 'lib/**'
         include 'man/man1/**'
         include 'release'
+        exclude '**/*.diz'
     }
     into "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}"
 }

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -124,12 +124,23 @@ task packageTestImage(type: Tar) {
         include '**'
     }
     into project.correttoTestImageArchiveName
+}
 
+task packageDebugSymbols(type: Tar) {
+    description 'Package debug results'
+    dependsOn packageTestImage
+    archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
+    compression Compression.GZIP
+    from(jdkResultingImage) {
+        include 'bin/*.diz'
+        include 'lib/*.diz'
+        into project.correttoDebugSymbolsArchiveName
+    }
 }
 
 task packageBuildResults(type: Tar) {
     description 'Compresses the JDK image and puts the results in build/distributions.'
-    dependsOn packageTestImage
+    dependsOn packageDebugSymbols
     archiveName "${project.correttoJdkArchiveName}.tar.gz"
     compression Compression.GZIP
     from(buildRoot) {
@@ -149,6 +160,7 @@ task packageBuildResults(type: Tar) {
         include 'lib/**'
         include 'man/man1/**'
         include 'release'
+        exclude '**/*.diz'
         into project.correttoJdkArchiveName
     }
 

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -132,6 +132,7 @@ task prepareArtifacts {
                 include "Contents/Home/release"
                 include "Contents/Info.plist"
                 include "Contents/MacOS/**"
+                exclude "Contents/Home/**/*.diz"
             }
             into "${buildDir}/${correttoMacDir}"
         }
@@ -155,6 +156,19 @@ task packaging(type: Exec) {
     outputs.file tarDir
 }
 
+task packageDebugSymbols(type: Tar) {
+    dependsOn prepareArtifacts
+    description 'Package debug symbols'
+    archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
+    compression Compression.GZIP
+    from("${jdkResultingImage}/${correttoMacDir}") {
+        include "Contents/Home/bin/*.diz"
+        include "Contents/Home/lib/*.diz"
+    }
+    into "${buildDir}/${correttoMacDir}"
+    into project.correttoDebugSymbolsArchiveName
+}
+
 task packageTestResults(type: Tar) {
     dependsOn executeTestBuild
     description 'Package test results'
@@ -164,10 +178,10 @@ task packageTestResults(type: Tar) {
         include '**'
     }
     into project.correttoTestImageArchiveName
-
 }
 
 build.dependsOn packaging
+build.dependsOn packageDebugSymbols
 build.dependsOn packageTestResults
 
 artifacts {

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -77,12 +77,24 @@ task packageTestImage(type: Zip) {
     into project.correttoTestImageArchiveName
 }
 
-task packageJdk(type: Zip) {
+task packageDebugSymbols(type: Zip) {
     dependsOn packageTestImage
+    archiveName "${project.correttoDebugSymbolsArchiveName}.zip"
+
+    from("${copyImage.destinationDir}/jdk") {
+        include 'bin/*.diz'
+        include 'lib/*.diz'
+        into project.correttoDebugSymbolsArchiveName
+    }
+}
+
+task packageJdk(type: Zip) {
+    dependsOn packageDebugSymbols
     archiveName  = "unsigned-jdk-image.zip"
 
     from("${copyImage.destinationDir}/jdk") {
         exclude 'demo'
+        exclude '**/*.diz'
     }
     from(buildRoot) {
         include 'ASSEMBLY_EXCEPTION'


### PR DESCRIPTION
Separately archive zipped debug symbols in release builds. Backport of https://github.com/corretto/corretto-17/pull/15. 

Tested on Windows, Mac, generic Linux, Alpine Linux.