### PR TITLE
Revert "Fix gcc warning in jvmti_tools.c"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.c
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.c
@@ -235,7 +235,7 @@ int nsk_jvmti_parseOptions(const char options[]) {
             nsk_complain("nsk_jvmti_parseOptions(): out of memory\n");
             return NSK_FALSE;
     }
-    strncpy(context.options.string, options, len-1);
+    strncpy(context.options.string, options, len);
     context.options.string[len] = '\0';
     context.options.string[len+1] = '\0';
 


### PR DESCRIPTION
This commit reverts '77d25831c6b498b4457c0b514e68ff3376f2227b'

Testing:

- `env CC=gcc10-gcc CXX=gcc10-g++ bash configure --with-jtreg=build/images/jtreg --enable-debug`
- `make run-test TEST=hotspot/jtreg/vmTestbase/nsk`