### PR TITLE
Revert "Backport 8219675: Disable harfbuzz warnings with gcc 8"

### DIFF
--- a/make/lib/Awt2dLibraries.gmk
+++ b/make/lib/Awt2dLibraries.gmk
@@ -571,61 +571,6 @@ else
   HARFBUZZ_DISABLED_WARNINGS_CXX_solstudio := \
         truncwarn wvarhidenmem wvarhidemem wbadlkginit identexpected \
         hidevf w_novirtualdescr arrowrtn2 unknownpragma
-  LIBHARFBUZZ_EXCLUDE_FILES += harfbuzz/hb-ft.cc
-
-  LIBHARFBUZZ_CFLAGS += $(HARFBUZZ_CFLAGS)
-
-  # For use by libfontmanager:
-  ifeq ($(OPENJDK_TARGET_OS), windows)
-    LIBHARFBUZZ_LIBS := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libharfbuzz/harfbuzz.lib
-  else
-    LIBHARFBUZZ_LIBS := -lharfbuzz
-  endif
-
-  LIBHARFBUZZ_EXTRA_HEADER_DIRS := \
-    libharfbuzz/hb-ucdn \
-    #
-
-  LIBHARFBUZZ_OPTIMIZATION := HIGH
-
-  LIBHARFBUZZ_CFLAGS += $(X_CFLAGS) -DLE_STANDALONE -DHEADLESS
-
-  $(eval $(call SetupJdkLibrary, BUILD_LIBHARFBUZZ, \
-      NAME := harfbuzz, \
-      EXCLUDE_FILES := $(LIBHARFBUZZ_EXCLUDE_FILES), \
-      TOOLCHAIN := TOOLCHAIN_LINK_CXX, \
-      CFLAGS := $(CFLAGS_JDKLIB) $(LIBHARFBUZZ_CFLAGS), \
-      CXXFLAGS := $(CXXFLAGS_JDKLIB) $(LIBHARFBUZZ_CFLAGS), \
-      OPTIMIZATION := $(LIBHARFBUZZ_OPTIMIZATION), \
-      CFLAGS_windows = -DCC_NOEX, \
-      EXTRA_HEADER_DIRS := $(LIBHARFBUZZ_EXTRA_HEADER_DIRS), \
-      WARNINGS_AS_ERRORS_xlc := false, \
-      DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing, \
-      DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
-          maybe-uninitialized missing-attributes class-memaccess, \
-      DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
-          tautological-constant-out-of-range-compare int-to-pointer-cast \
-          undef missing-field-initializers, \
-      DISABLED_WARNINGS_C_solstudio := \
-          E_INTEGER_OVERFLOW_DETECTED \
-          E_ARG_INCOMPATIBLE_WITH_ARG_L \
-          E_ENUM_VAL_OVERFLOWS_INT_MAX, \
-      DISABLED_WARNINGS_CXX_solstudio := \
-          truncwarn wvarhidenmem wvarhidemem wbadlkginit identexpected \
-          hidevf w_novirtualdescr arrowrtn2 unknownpragma, \
-      DISABLED_WARNINGS_microsoft := 4267 4244 4090 4146 4334 4819 4101 4068 4805 4138, \
-      LDFLAGS := $(LIBHARFBUZZ_LDFLAGS), \
-      LDFLAGS_unix := -L$(INSTALL_LIBRARIES_HERE), \
-      LDFLAGS_aix := -Wl$(COMMA)-berok, \
-      LIBS := $(BUILD_LIBHARFBUZZ), \
-      LIBS_unix := $(LIBM) $(LIBCXX), \
-      LIBS_macosx := -framework CoreText -framework CoreFoundation -framework CoreGraphics, \
-      LIBS_windows := user32.lib, \
-  ))
-
-  ifeq ($(FREETYPE_TO_USE), bundled)
-    $(BUILD_LIBHARFBUZZ): $(BUILD_LIBFREETYPE)
-  endif
 
   LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
 


### PR DESCRIPTION
I think this is what happened here, and why this code was added:
1. Initially the fix for 8219675 was backported to fix a build issue in the harfbuzz library: https://github.com/corretto/corretto-11/commit/596f63a2460e87572cfff98b62f5e14b3487b634
2. Unfortunately the fix above does not work in corretto-11 because the next fix was backported as well: https://github.com/corretto/corretto-11/commit/a5e0d67e52401d94f5d43b725afff2f35cc45a61 The root cause of the problem is that the harfbuzz code was extracted to the separate library, so the disabled warning at step 1 was added to the libfontmanager did not work.
3. I think the initial fix was reverted: https://github.com/corretto/corretto-11/commit/4cfe228df5e1d27e30055508be5d9f12ee2775d5 and the new version were implemented.
4. Unfortunately the fix pushed at step 2 above was reverted as well: https://github.com/corretto/corretto-11/commit/6a6e00e56b57006fc80e7b3560c860a0f0967111
5. The "new" version of the fix from step 1 was pushed: https://github.com/corretto/corretto-11/commit/0cc8d1619fc0b0fd9f93e4baac4c672c5e94e206

The last commit from step 5 produced the merge conflict (take a look at the last line). But it did not hurt much because eventually, that was a dead code, since the "$(eval $(call SetupJdkLibrary, BUILD_LIBHARFBUZZ, \" was never executed - hurfbuzz is embedded to the libfontmanager since then again.

I guess the root cause of all of this is a different order of backports from the upstream. After the fix, this file will be identical to the current jdk11u version.