### PR TITLE
Enable the UseAESCTRIntrinsics by default

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -217,7 +217,7 @@ void VM_Version::initialize() {
       UseAES = true;
     }
     if (FLAG_IS_DEFAULT(UseAESCTRIntrinsics)) {
-      FLAG_SET_DEFAULT(UseAESCTRIntrinsics, false);
+      FLAG_SET_DEFAULT(UseAESCTRIntrinsics, true);
     }
   } else {
     if (UseAES) {


### PR DESCRIPTION
This is a request to enable the UseAESCTRIntrinsics by default since it provides a great performance improvement.

Performance tests were executed on c6g.4xlarge:

```
Fix:
Benchmark                                     (dataSize)  (keyLength)  (provider)  Mode  Cnt      Score    Error  Units
o.o.b.j.c.full.AESGCMBench.decrypt                 16384          128              avgt   10  12212.033 ±  4.745  ns/op
o.o.b.j.c.full.AESGCMBench.decryptMultiPart        16384          128              avgt   10  16708.177 ± 86.632  ns/op
o.o.b.j.c.full.AESGCMBench.encrypt                 16384          128              avgt   10  10227.456 ± 22.908  ns/op
o.o.b.j.c.full.AESGCMBench.encryptMultiPart        16384          128              avgt   10  10286.206 ± 17.259  ns/op
o.o.b.j.c.small.AESGCMBench.decryptMultiPart        1024          128              avgt   10   1687.860 ±  0.732  ns/op
o.o.b.j.c.small.AESGCMBench.encrypt                 1024          128              avgt   10   1069.473 ±  0.453  ns/op
o.o.b.j.c.small.AESGCMBench.encryptMultiPart        1024          128              avgt   10   1113.857 ±  0.292  ns/op

Base:
Benchmark                                     (dataSize)  (keyLength)  (provider)  Mode  Cnt      Score      Error  Units
o.o.b.j.c.full.AESGCMBench.decrypt                 16384          128              avgt   10  84111.953 ±  530.874  ns/op
o.o.b.j.c.full.AESGCMBench.decryptMultiPart        16384          128              avgt   10  86638.828 ±  141.915  ns/op
o.o.b.j.c.full.AESGCMBench.encrypt                 16384          128              avgt   10  81080.991 ±  888.818  ns/op
o.o.b.j.c.full.AESGCMBench.encryptMultiPart        16384          128              avgt   10  83445.267 ± 1054.195  ns/op
o.o.b.j.c.small.AESGCMBench.decrypt                 1024          128              avgt   10   5776.296 ±   13.794  ns/op
o.o.b.j.c.small.AESGCMBench.decryptMultiPart        1024          128              avgt   10   5776.862 ±   17.814  ns/op
o.o.b.j.c.small.AESGCMBench.encrypt                 1024          128              avgt   10   5460.580 ±    7.325  ns/op
o.o.b.j.c.small.AESGCMBench.encryptMultiPart        1024          128              avgt   10   5626.897 ±   26.081  ns/op
```

I have completed the jtreg:tier1, jtreg:tier2, jtreg:tier3, jtreg:tier4 tests no new issues were found.

