### PR TITLE
Restore SecurityUtils.removeFromDisabledTlsAlgs()

### DIFF
--- a/test/lib/jdk/test/lib/security/SecurityUtils.java
+++ b/test/lib/jdk/test/lib/security/SecurityUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,10 @@ package jdk.test.lib.security;
 
 import java.io.File;
 import java.security.KeyStore;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Common library for various security test helper functions.
@@ -46,6 +50,24 @@ public final class SecurityUtils {
             return null;
         }
         return KeyStore.getInstance(file, (char[])null);
+    }
+
+    /**
+     * Removes the specified protocols from the jdk.tls.disabledAlgorithms
+     * security property.
+     */
+    public static void removeFromDisabledTlsAlgs(String... protocols) {
+        removeFromDisabledAlgs("jdk.tls.disabledAlgorithms",
+                               List.<String>of(protocols));
+    }
+
+    private static void removeFromDisabledAlgs(String prop, List<String> algs) {
+        String value = Security.getProperty(prop);
+        value = Arrays.stream(value.split(","))
+                      .map(s -> s.trim())
+                      .filter(s -> !algs.contains(s))
+                      .collect(Collectors.joining(","));
+        Security.setProperty(prop, value);
     }
 
     private SecurityUtils() {}


### PR DESCRIPTION
This utility method was added to the jdk11u as part of the "8202343: Disable TLS 1.0 and 1.1", that change was reverted in the corretto-11. But this utility method starts to be used in the new test cases. So that new test cases failed in the corretto-11.

This is a request to restore just this utility method, so the new tests could be compiled and passed.