### PR TITLE
DebugReportsOneExtraByte should check new protocol version in debug o…

### DIFF
--- a/test/jdk/sun/security/ssl/EngineArgs/DebugReportsOneExtraByte.sh
+++ b/test/jdk/sun/security/ssl/EngineArgs/DebugReportsOneExtraByte.sh
@@ -54,7 +54,7 @@ esac
 ${COMPILEJAVA}${FS}bin${FS}javac ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} -d . \
     ${TESTSRC}${FS}DebugReportsOneExtraByte.java
 
-STRING='WRITE: TLS10 application_data, length = 8'
+STRING='WRITE: TLSv1 application_data, length = 8'
 
 echo "Examining debug output for the string:"
 echo "${STRING}"


### PR DESCRIPTION
In the jdk11u the DebugReportsOneExtraByte test was reimplemented by the "8202343: Disable TLS 1.0 and 1.1" fix but that fix is not present in the corretto-11.

Recently that new code in this test was updated by the [8211227: Inconsistent TLS protocol version in debug output ](https://github.com/openjdk/jdk11u-dev/commit/124f3aca23ddf7c4f5a5959b1519dcf5b610be3b#diff-1aa00612031ab67601737704152bc6c67f5da0f2d00977d2a4928ef87e671d09R134). And this is a request to do the same change in the shellcode in our version of the test.