### PR TITLE
Adding automatic version updates

### DIFF
--- a/.github/actions/update-version/action.yml
+++ b/.github/actions/update-version/action.yml
@@ -1,0 +1,19 @@
+name: 'Update Corretto version'
+description: 'Update the version based on upstream configuration'
+
+inputs:
+    upstream:
+        description: 'upstream remote suffix'
+        required: true
+    version-branch:
+        description: 'Branch to update version of'
+        required: true
+outputs:
+    status:
+        description: 'Status of the update of the version'
+runs:
+    using: "composite"
+    steps:
+        - run: $GITHUB_ACTION_PATH/update-version.sh ${{ inputs.upstream }} ${{ inputs.version-branch }}
+          shell: bash
+          id: update-version

--- a/.github/actions/update-version/update-version.sh
+++ b/.github/actions/update-version/update-version.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -x
+
+UPSTREAM_REMOTE=upstream-$1
+VERSION_BRANCH=$2
+
+git config user.email "no-reply@amazon.com"
+git config user.name "corretto-github-robot"
+
+git checkout ${VERSION_BRANCH}
+
+# Load the current OpenJDK version
+source make/autoconf/version-numbers
+
+BUILD_NUMBER=$(git ls-remote --tags ${UPSTREAM_REMOTE} |grep jdk-${DEFAULT_VERSION_FEATURE}+ | grep -vE "(-ga|{})$" | cut -d+ -f 2 |sort -n |tail -1)
+
+# Load the current Corretto version
+CURRENT_VERSION=$(cat version.txt)
+
+if [[ ${CURRENT_VERSION} == ${DEFAULT_VERSION_FEATURE}.${DEFAULT_VERSION_INTERIM}.${DEFAULT_VERSION_UPDATE}.${BUILD_NUMBER}.* ]]; then
+    echo "Corretto version is current."
+else
+    echo "Updating Corretto version"
+    NEW_VERSION="${DEFAULT_VERSION_FEATURE}.${DEFAULT_VERSION_INTERIM}.${DEFAULT_VERSION_UPDATE}.${BUILD_NUMBER}.1"
+    echo  "${NEW_VERSION}" > version.txt
+    git commit -m "Update Corretto version to match upstream: ${NEW_VERSION}" version.txt
+    #git push origin ${VERSION_BRANCH}
+fi

--- a/.github/workflows/fetch-dev-repo.yml
+++ b/.github/workflows/fetch-dev-repo.yml
@@ -24,3 +24,8 @@ jobs:
               with:
                 upstream: 'upstream-dev'
                 merge-branch: 'nightly'
+            - name: "Update Corretto version"
+              uses: ./.github/actions/update-version
+              with:
+                upstream: 'upstream-dev'
+                version-branch: 'nightly'

--- a/.github/workflows/fetch-repo.yml
+++ b/.github/workflows/fetch-repo.yml
@@ -24,6 +24,11 @@ jobs:
               with:
                 upstream: 'upstream'
                 merge-branch: 'develop'
+            - name: "Update Corretto version"
+              uses: ./.github/actions/update-version
+              with:
+                upstream: 'upstream'
+                version-branch: 'develop'
             - name: "Merge Corretto-11 develop to nightly"
               uses: ./.github/actions/merge-repo
               with:


### PR DESCRIPTION
Backporting the version.txt updating from CorrettoJdk with the required minor change the the path to get versions. 

Unfortunately no good way to test this, it can run the updated workflow from a branch but doesn't see to use the updated actions.