### PR TITLE
Add pat num to UseSIMDForMemoryOps

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -150,7 +150,7 @@ void VM_Version::initialize() {
   }
 
   // Neoverse N1
-  if (_cpu == CPU_ARM && (_model == 0xd0c || _model2 == 0xd0c)) {
+  if (_cpu == CPU_ARM && (_model == 0xd0c || _model2 == 0xd0c || _model == 3392 || _model2 == 3392)) {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }


### PR DESCRIPTION
This will reapply the https://github.com/corretto/corretto-11/commit/3d39471a611c25b8e5d03041485ee4cff102715f patch. (It was temporarily reverted due to unplanned release)