### PR TITLE
8247589: Implementation of Alpine Linux/x64 Port (partial backport).

### DIFF
--- a/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
+++ b/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
@@ -30,6 +30,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static jdk.test.lib.process.ProcessTools.createJavaProcessBuilder;
 import static jdk.test.lib.Platform.isWindows;
+import jdk.test.lib.Platform;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -194,7 +195,14 @@ public class TestInheritFD {
     }
 
     static boolean findOpenLogFile(Collection<String> fileNames) {
+        String pid = Long.toString(ProcessHandle.current().pid());
+        String[] command = lsofCommand().orElseThrow(() ->
+                new RuntimeException("lsof like command not found"));
+        String lsof = command[0];
+        boolean isBusybox = Platform.isBusybox(lsof);
         return fileNames.stream()
+            // lsof from busybox does not support "-p" option
+            .filter(fileName -> !isBusybox || fileName.contains(pid))
             .filter(fileName -> fileName.contains(LOG_SUFFIX))
             .findAny()
             .isPresent();

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -26,6 +26,9 @@ package jdk.test.lib;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -105,6 +108,18 @@ public class Platform {
 
     public static boolean isLinux() {
         return isOs("linux");
+    }
+
+    public static boolean isBusybox(String tool) {
+        try {
+            Path toolpath = Paths.get(tool);
+            return !isWindows()
+                    && Files.isSymbolicLink(toolpath)
+                    && Paths.get("/bin/busybox")
+                        .equals(Files.readSymbolicLink(toolpath));
+        } catch (IOException ignore) {
+            return false;
+        }
     }
 
     public static boolean isOSX() {


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto 11.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 11
and is not specific to Corretto 11,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 11,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
Partial backport of https://bugs.openjdk.java.net/browse/JDK-8247589. The patch updates a lot of things related to Alpine, but I specifically extracted the part of the patch that allows us to pass `TestInheritFD.java`. Before this patch, the test attempts to use `lsof -p`, but the `-p` flag is not supported in busybox lsof.

 I don't think this is getting merged to upstream OpenJDK, because they don't support Alpine on OpenJDK 11.

This also should be backported to Corretto 8.




### How has this been tested?
`TestInheritFD.java` passes in jenkins.


### Platform information
    Alpine
