### PR TITLE
Alpine build uses common Corretto flags.

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -80,23 +80,12 @@ task configureBuild(type: Exec) {
     def configureCmd = [
         'bash',
         'configure',
-        '--with-jvm-features=zgc shenandoahgc',
         "--with-version-feature=${version.major}",
-        '--with-freetype=bundled',
         '--with-zlib=bundled',
-        "--with-version-opt=${versionOpt}",
-        "--with-version-build=${version.build}",
-        "--with-vendor-version-string=Corretto-${version.full}",
-        '--with-version-pre=',
-        '--with-vendor-name=Amazon.com Inc.',
-        '--with-vendor-url=https://aws.amazon.com/corretto/',
-        "--with-vendor-bug-url=https://github.com/corretto/corretto-${version.major}/issues/",
-        "--with-vendor-vm-bug-url=https://github.com/corretto/corretto-${version.major}/issues/",
-        '--with-debug-level=release',
-        '--with-native-debug-symbols=none',
         '--with-stdc++lib=static',
         '--disable-warnings-as-errors'
     ]
+    configureCmd += project.correttoCommonFlags
 
     def versionDate = project.findProperty("corretto.versionDate")
     if (versionDate) {


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto 11.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 11
and is not specific to Corretto 11,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 11,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
Alpine `configure` command uses `correttoCommonFlags`. Currently, Corretto 11 builds for Alpine do not build debug symbols because of `--with-native-debug-symbols=none`. By using `correttoCommonFlags`, the commands not have the right debug symbols flags, and we have parity between flags of different platforms.

Corretto 8 alpine builds do build debug symbols, but do not use `correttoCommonFlags`. There is no bug, but is probably worth cleaning up.


### How has this been tested?
Build locally and in Jenkins pipeline

### Platform information
    Alpine


