### PR TITLE
Add config files as config | no replace

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,24 @@ allprojects {
         caCerts = "cacerts"
         sourceTar = "amazon-corretto-source-${project.version.full}.tar.gz"
 
+        configurationFiles = [
+            'conf/logging.properties',
+            'conf/net.properties',
+            'conf/sound.properties',
+            'conf/security/policy/limited/default_local.policy',
+            'conf/security/policy/limited/exempt_local.policy',
+            'conf/security/policy/limited/default_US_export.policy',
+            'conf/security/policy/unlimited/default_local.policy',
+            'conf/security/policy/unlimited/default_US_export.policy',
+            'conf/security/java.policy',
+            'conf/security/java.security',
+            'conf/management/jmxremote.access',
+            'conf/management/management.properties',
+            'lib/security/blocked.certs',
+            'lib/security/default.policy',
+            'lib/security/public_suffix_list.dat'
+            ];
+
         versionOpt = project.findProperty("corretto.versionOpt") ?: "LTS"
         correttoCommonFlags = [
                 "--with-freetype=bundled",

--- a/installers/linux/al2/spec/java-11-amazon-corretto-modular.spec.template
+++ b/installers/linux/al2/spec/java-11-amazon-corretto-modular.spec.template
@@ -327,6 +327,21 @@ fi
 %{java_inc}/linux/jawt_md.h
 
 %files headless
+%config(noreplace) %{java_home}/conf/logging.properties
+%config(noreplace) %{java_home}/conf/net.properties
+%config(noreplace) %{java_home}/conf/sound.properties
+%config(noreplace) %{java_home}/conf/management/jmxremote.access
+%config(noreplace) %{java_home}/conf/management/management.properties
+%config(noreplace) %{java_home}/conf/security/java.policy
+%config(noreplace) %{java_home}/conf/security/java.security
+%config(noreplace) %{java_home}/conf/security/policy/limited/exempt_local.policy
+%config(noreplace) %{java_home}/conf/security/policy/limited/default_local.policy
+%config(noreplace) %{java_home}/conf/security/policy/limited/default_US_export.policy
+%config(noreplace) %{java_home}/conf/security/policy/unlimited/default_local.policy
+%config(noreplace) %{java_home}/conf/security/policy/unlimited/default_US_export.policy
+%config(noreplace) %{java_home}/lib/security/blocked.certs
+%config(noreplace) %{java_home}/lib/security/default.policy
+%config(noreplace) %{java_home}/lib/security/public_suffix_list.dat
 %{java_home}/bin/java
 %{java_home}/bin/jjs
 %{java_home}/bin/keytool

--- a/installers/linux/al2/spec/java-11-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-11-amazon-corretto.spec.template
@@ -292,6 +292,21 @@ fi
 %{java_inc}/linux/jawt_md.h
 
 %files headless
+%config(noreplace) %{java_home}/conf/logging.properties
+%config(noreplace) %{java_home}/conf/net.properties
+%config(noreplace) %{java_home}/conf/sound.properties
+%config(noreplace) %{java_home}/conf/management/jmxremote.access
+%config(noreplace) %{java_home}/conf/management/management.properties
+%config(noreplace) %{java_home}/conf/security/java.policy
+%config(noreplace) %{java_home}/conf/security/java.security
+%config(noreplace) %{java_home}/conf/security/policy/limited/exempt_local.policy
+%config(noreplace) %{java_home}/conf/security/policy/limited/default_local.policy
+%config(noreplace) %{java_home}/conf/security/policy/limited/default_US_export.policy
+%config(noreplace) %{java_home}/conf/security/policy/unlimited/default_local.policy
+%config(noreplace) %{java_home}/conf/security/policy/unlimited/default_US_export.policy
+%config(noreplace) %{java_home}/lib/security/blocked.certs
+%config(noreplace) %{java_home}/lib/security/default.policy
+%config(noreplace) %{java_home}/lib/security/public_suffix_list.dat
 %{java_home}
 
 # Keep the libs and includes that need X11 in the main package

--- a/installers/linux/universal/deb/build.gradle
+++ b/installers/linux/universal/deb/build.gradle
@@ -174,8 +174,17 @@ task generateJdkDeb(type: Deb) {
     provides('java11-runtime-headless')
 
     from(jdkBinaryDir) {
+        include(project.configurationFiles)
+        // Deb actually uses configuationFile and not fileType see https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/118#issuecomment-656004360
+        // Path must be the fully qualified install path
+        configurationFile = project.configurationFiles.collect{ "${jdkHome}/${it}" }.join("\n")
+        into jdkHome
+    }
+
+    from(jdkBinaryDir) {
         into jdkHome
         exclude 'legal'
+        exclude(project.configurationFiles)
     }
 
     // Copy legal directory specifically to set permission correctly.
@@ -185,7 +194,7 @@ task generateJdkDeb(type: Deb) {
         fileMode 0444
     }
 
-    from("$buildRoot/jinfo") {
+    from("${buildRoot}/jinfo") {
         include '**/*.jinfo'
         into jvmDir
     }

--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -129,8 +129,15 @@ task generateJdkRpm(type: Rpm) {
     provides('java-11-openjdk', "${epoch}:${version}-${release}", EQUAL)
 
     from(jdkBinaryDir) {
+        include(project.configurationFiles)
+        fileType CONFIG | NOREPLACE
+        into jdkHome
+    }
+
+    from(jdkBinaryDir) {
         into jdkHome
         exclude 'legal'
+        exclude(project.configurationFiles)
     }
 
     // Copy legal directory specifically to set permission correctly.

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -44,7 +44,7 @@ if (project.correttoArch == 'armv7') {
         ]
 }
 
-def imageDir= "$buildRoot/build/${project.jdkImageName}/images"
+def imageDir = "$buildRoot/build/${project.jdkImageName}/images"
 def jdkResultingImage = "${imageDir}/jdk"
 def testResultingImage = "${imageDir}/test"
 


### PR DESCRIPTION
Backporting from CorrettoJDK

Built AL2 rpms, both monolithic and modular, and universal rpm/deb for x64 and it looks good.
