### PR TITLE
Arm musl-libc support

### DIFF
--- a/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
@@ -71,7 +71,9 @@
 # include <pwd.h>
 # include <poll.h>
 # include <ucontext.h>
+#if defined __GLIBC__
 # include <fpu_control.h>
+#endif
 # include <asm/ptrace.h>
 
 #define SPELL_REG_SP  "sp"
@@ -101,6 +103,7 @@ char* os::non_memory_address_word() {
 
 #else
 
+#if defined __GLIBC__
 #if NGREG == 16
 // These definitions are based on the observation that until
 // the certain version of GCC mcontext_t was defined as
@@ -112,6 +115,7 @@ char* os::non_memory_address_word() {
 #define arm_fp gregs[11]
 #define arm_r0 gregs[0]
 #endif
+#endif // __GLIBC__
 
 #define ARM_REGS_IN_CONTEXT  16
 


### PR DESCRIPTION
### Description
The change allows to build arm musl-libc version of Corretto 11 (f.e. alpine arm)

### Related issues
https://bugs.openjdk.java.net/browse/JDK-8247589

### How has this been tested?
Successfully built arm32 musl linux version to check the change. 
Built and tested for other platforms and os to check it does not break anything. 

### Platform information
    Works on OS: linux arm musl-libc
    Applies to version: 11.0.16.1.1
