### PR TITLE
Adding headless and arm musl to gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* Copyright (c) 2019, 2022, Amazon.com, Inc. or its affiliates. All Rights Reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -104,14 +104,11 @@ allprojects {
             correttoCommonFlags += ["--with-version-date=${versionDate}"]
         }
 
-        is_x86 = false
-        is_armv7 = false
-        if (project.hasProperty("x86")) {
-            is_x86 = Boolean.valueOf("${project.getProperty('x86')}")
-        }
-        if (project.hasProperty("armv7")) {
-            is_armv7 = Boolean.valueOf("${project.getProperty('armv7')}")
-        }
+        is_x86 = project.hasProperty("x86") ? Boolean.valueOf("${project.getProperty('x86')}") : false
+        is_armv7 = project.hasProperty("armv7") ? Boolean.valueOf("${project.getProperty('armv7')}") : false
+        is_musl = project.hasProperty("musl") ? Boolean.valueOf("${project.getProperty('musl')}") : false
+        is_headless = project.hasProperty("headless") ? Boolean.valueOf("${project.getProperty('headless')}") : false
+
         if (is_x86) {
             correttoCommonFlags += ["--with-target-bits=32"]
         } else if (!is_armv7) {
@@ -119,6 +116,8 @@ allprojects {
             // flag, which is in conflict with '--with-target-bits'.
             correttoCommonFlags += ["--with-target-bits=64"]
         }
+
+        correttoCommonFlags += '--enable-headless-only=' + (is_headless ? "yes" : "no")
 
         // Valid value: null, release, debug, fastdebug, slowdebug
         def correttoDebugLevel = "release" // Default: release
@@ -207,15 +206,17 @@ allprojects {
 
         // Call toString explicitly to avoid lazy evaluation
         jdkImageName = "${os}-${jdkArch}-normal-server-${correttoDebugLevel}".toString()
+        archSuffix = is_musl ? "-musl" : ""
+        headless = is_headless ? "-headless" : ""
         // no debug level suffix for release build
         if (correttoDebugLevel == "release") {
-            correttoJdkArchiveName = "amazon-corretto-${project.version.full}-${os}-${correttoArch}".toString()
+            correttoJdkArchiveName = "amazon-corretto${headless}-${project.version.full}-${os}-${correttoArch}${archSuffix}".toString()
         } else {
             correttoJdkArchiveName =
-                    "amazon-corretto-${project.version.full}-${os}-${correttoArch}-${correttoDebugLevel}".toString()
+                    "amazon-corretto${headless}-${project.version.full}-${os}-${correttoArch}${archSuffix}-${correttoDebugLevel}".toString()
         }
-        correttoDebugSymbolsArchiveName = "amazon-corretto-debugsymbols-${project.version.full}-${os}-${correttoArch}".toString()
-        correttoTestImageArchiveName = "amazon-corretto-testimage-${project.version.full}-${os}-${correttoArch}".toString()
+        correttoDebugSymbolsArchiveName = "amazon-corretto${headless}-debugsymbols-${project.version.full}-${os}-${correttoArch}${archSuffix}".toString()
+        correttoTestImageArchiveName = "amazon-corretto${headless}-testimage-${project.version.full}-${os}-${correttoArch}${archSuffix}".toString()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -210,13 +210,13 @@ allprojects {
         headless = is_headless ? "-headless" : ""
         // no debug level suffix for release build
         if (correttoDebugLevel == "release") {
-            correttoJdkArchiveName = "amazon-corretto${headless}-${project.version.full}-${os}-${correttoArch}${archSuffix}".toString()
+            correttoJdkArchiveName = "amazon-corretto-${project.version.full}-${os}-${correttoArch}${archSuffix}${headless}".toString()
         } else {
             correttoJdkArchiveName =
-                    "amazon-corretto${headless}-${project.version.full}-${os}-${correttoArch}${archSuffix}-${correttoDebugLevel}".toString()
+                    "amazon-corretto-${project.version.full}-${os}-${correttoArch}${archSuffix}${headless}-${correttoDebugLevel}".toString()
         }
-        correttoDebugSymbolsArchiveName = "amazon-corretto${headless}-debugsymbols-${project.version.full}-${os}-${correttoArch}${archSuffix}".toString()
-        correttoTestImageArchiveName = "amazon-corretto${headless}-testimage-${project.version.full}-${os}-${correttoArch}${archSuffix}".toString()
+        correttoDebugSymbolsArchiveName = "amazon-corretto-debugsymbols-${project.version.full}-${os}-${correttoArch}${archSuffix}${headless}".toString()
+        correttoTestImageArchiveName = "amazon-corretto-testimage-${project.version.full}-${os}-${correttoArch}${archSuffix}${headless}".toString()
     }
 }
 

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* Copyright (c) 2019, 2022, Amazon.com, Inc. or its affiliates. All Rights Reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -39,10 +39,25 @@ if (project.correttoArch == 'armv7') {
     archSpecificFlags += [
             '--with-sysroot=/opt/sysroot/',
             '--with-toolchain-path=/opt/sysroot/',
-            '--openjdk-target=arm-linux-gnueabihf',
             '--disable-warnings-as-errors'
+    ]
+    if (project.is_musl) {
+        archSpecificFlags += [
+                '--openjdk-target=arm-unknown-linux-musleabihf',
+                '--with-stdc++lib=static',
+                '--with-extra-cflags=-Os -fomit-frame-pointer -g',
+                '--with-extra-cxxflags=-Os -fomit-frame-pointer -g',
+                '--with-extra-ldflags=-Wl,--as-needed',
+                '--with-extra-asflags=-Os -fomit-frame-pointer -g',
+                '--with-extra-cflags=-DMUSL_LIBC'
         ]
+    } else {
+        archSpecificFlags += [
+                '--openjdk-target=arm-linux-gnueabihf'
+        ]
+    }
 }
+
 
 def imageDir = "$buildRoot/build/${project.jdkImageName}/images"
 def jdkResultingImage = "${imageDir}/jdk"


### PR DESCRIPTION
### Description
Updates for the gradle build to execute build for headless and arm musl. 

### Related issues
https://github.com/corretto/corretto-11/pull/256

### How has this been tested?
Successfully built arm musl headless linux version via gradle to check the change.
Built and tested for other platforms and os to check it does not break anything.

### Platform information
    Works on OS: linux
    Applies to version: 11.0.16.4.1
