### PR TITLE
Only require log4j-cve-mitigations on AL2

### DIFF
--- a/installers/linux/al2/spec/java-11-amazon-corretto-modular.spec.template
+++ b/installers/linux/al2/spec/java-11-amazon-corretto-modular.spec.template
@@ -148,7 +148,9 @@ Requires: zlib
 Requires: fontconfig
 Requires: freetype
 Requires: ca-certificates
-#Requires: log4j-cve-2021-44228-cve-mitigations
+%if "%{dist}" == ".amzn2"
+Requires: log4j-cve-2021-44228-cve-mitigations
+%endif
 Requires(post): chkconfig
 Requires(postun): chkconfig
 

--- a/installers/linux/al2/spec/java-11-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-11-amazon-corretto.spec.template
@@ -144,7 +144,9 @@ Requires: zlib
 Requires: fontconfig
 Requires: freetype
 Requires: ca-certificates
+%if "%{dist}" == ".amzn2"
 Requires: log4j-cve-2021-44228-cve-mitigations
+%endif
 Requires(post): chkconfig
 Requires(postun): chkconfig
 


### PR DESCRIPTION
Don't require the log4j mitigation on AL2022+
