### PR TITLE
Enable bundled zlib library via Gradle

### DIFF
--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -69,6 +69,9 @@ task configureBuild(type: Exec) {
     def command = ['bash', 'configure',
             "--with-cacerts-file=${depsMap[caCerts]}"
     ]
+    if (project.correttoArch == "aarch64") {
+        command += "--with-zlib=bundled"
+    }
     // Common flags
     command += project.correttoCommonFlags
     commandLine command.flatten()


### PR DESCRIPTION
Backport of https://github.com/corretto/corretto-jdk/pull/78 to the corretto-11