### PR TITLE
AL: Fix alternatives command

### DIFF
--- a/installers/linux/al2/spec/java-11-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-11-amazon-corretto.spec.template
@@ -237,7 +237,7 @@ if [ \$1 -eq 1 ] ; then
                --slave %{_mandir}/man1/rmiregistry.1 rmiregistry.1 %{java_home}/man/man1/rmiregistry.1 \\
                --slave %{_mandir}/man1/unpack200.1 unpack200.1 %{java_home}/man/man1/unpack200.1
 
-  alternatives --install %{_jvmdir}/jre-%{java_major_version} jre_%{java_major_version} %{java_home} \\
+  alternatives --install %{_jvmdir}/jre-%{java_major_version} jre_%{java_major_version} %{java_home}  %{alternatives_priority} \\
               --slave %{_jvmdir}/jre-%{java_major_version}-openjdk jre_%{java_major_version}_openjdk %{java_home}
 
   alternatives --install %{_bindir}/javac javac %{java_home}/bin/javac %{alternatives_priority} \\


### PR DESCRIPTION
Missed adding the alternatives priority which results in unexpected output during install/uinstall but still succeeds.

### How has this been tested?
Built AL2 x64 rpm locally and installed, no unexpected output.
