### PR TITLE
Revert "Update expected binary path"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,7 @@ allprojects {
         }
 
         // Call toString explicitly to avoid lazy evaluation
-        jdkImageName = "${os}-${jdkArch}-server-${correttoDebugLevel}".toString()
+        jdkImageName = "${os}-${jdkArch}-normal-server-${correttoDebugLevel}".toString()
         archSuffix = is_musl ? "-musl" : ""
         headless = is_headless ? "-headless" : ""
         // no debug level suffix for release build

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -40,8 +40,8 @@ ext {
     }
 }
 
-def jdkResultingImage = "$buildRoot/build/linux-${arch}-server-release/images/jdk"
-def testResultingImage = "$buildRoot/build/linux-${arch}-server-release/images/test"
+def jdkResultingImage = "$buildRoot/build/linux-${arch}-normal-server-release/images/jdk"
+def testResultingImage = "$buildRoot/build/linux-${arch}-normal-server-release/images/test"
 
 /**
  * Create a local copy of the source tree in our


### PR DESCRIPTION
This reverts commit ad6f555128b814301956bbd083ac5e3a2090d3ec.

Upstream reverted 8210962 with 8294138 (see https://github.com/corretto/corretto-11/commit/bd69a238eaa66f89c132c22fe145c6ed2015e8c4), so the CONF_NAME part is changed back.

Tested through automation.
