### PR TITLE
Relax VerifyCACerts expiry condition

### DIFF
--- a/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
+++ b/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
@@ -543,27 +543,26 @@ public class VerifyCACerts {
                         + e.getMessage());
             }
 
-            // Make sure cert is not expired or not yet valid
             try {
                 cert.checkValidity();
             } catch (CertificateExpiredException cee) {
-                if (!EXPIRY_EXC_ENTRIES.contains(alias)) {
-                    atLeastOneFailed = true;
-                    System.err.println("ERROR: cert is expired");
-                }
+                // Ignore - we have an 'is very expired' check later
             } catch (CertificateNotYetValidException cne) {
                 atLeastOneFailed = true;
                 System.err.println("ERROR: cert is not yet valid");
             }
 
-            // If cert is within 90 days of expiring, mark as failure so
-            // that cert can be scheduled to be removed/renewed.
+            // If cert is more than 90 days *past* expiry, mark as failure so
+            // we can alert either OpenJDK upstream or Amazon Linux.
+            // This is different to the upstream failure condition, which fails
+            // 90 days *before* expiry. Our condition is more relaxed because we
+            // rely on OpenJDK/Amazon Linux to manage the certs.
             Date notAfter = cert.getNotAfter();
-            if (notAfter.getTime() - System.currentTimeMillis() < NINETY_DAYS) {
+            if (System.currentTimeMillis() - notAfter.getTime() > NINETY_DAYS) {
                 if (!EXPIRY_EXC_ENTRIES.contains(alias)) {
                     atLeastOneFailed = true;
                     System.err.println("ERROR: cert \"" + alias + "\" expiry \""
-                            + notAfter.toString() + "\" will expire within 90 days");
+                            + notAfter.toString() + "\" has been expired for >90 days.");
                 }
             }
         }


### PR DESCRIPTION
### Description
Backport https://github.com/corretto/corretto-jdk/commit/13cbe35a9eeaf7e47c9d99f1293663967df54231
Relax VerifyCACerts expiry condition
