### PR TITLE
8258005: JDK build fails with incorrect fixpath script

### DIFF
--- a/make/autoconf/basic_windows.m4
+++ b/make/autoconf/basic_windows.m4
@@ -121,7 +121,7 @@ AC_DEFUN([BASIC_SETUP_PATHS_WINDOWS],
   else
     WINENV_PREFIX_ARG="$WINENV_PREFIX"
   fi
-  FIXPATH_ARGS="-e $PATHTOOL -p $WINENV_PREFIX_ARG -r ${WINENV_ROOT/\\/\\\\}  -t $WINENV_TEMP_DIR -c $CMD -q"
+  FIXPATH_ARGS="-e $PATHTOOL -p $WINENV_PREFIX_ARG -r ${WINENV_ROOT//\\/\\\\}  -t $WINENV_TEMP_DIR -c $CMD -q"
   FIXPATH_BASE="$BASH $FIXPATH_DIR/fixpath.sh $FIXPATH_ARGS"
   FIXPATH="$FIXPATH_BASE exec"
 
@@ -166,7 +166,7 @@ AC_DEFUN([BASIC_WINDOWS_FINALIZE_FIXPATH],
 [
   if test "x$OPENJDK_BUILD_OS" = xwindows; then
     FIXPATH_CMDLINE=". $TOPDIR/make/scripts/fixpath.sh -e $PATHTOOL \
-        -p $WINENV_PREFIX_ARG -r ${WINENV_ROOT/\\/\\\\}  -t $WINENV_TEMP_DIR \
+        -p $WINENV_PREFIX_ARG -r ${WINENV_ROOT//\\/\\\\}  -t $WINENV_TEMP_DIR \
         -c $CMD -q"
     $ECHO >  $OUTPUTDIR/fixpath '#!/bin/bash'
     $ECHO >> $OUTPUTDIR/fixpath export PATH='"[$]PATH:'$PATH'"'


### PR DESCRIPTION
Backport-of: 0890620c94cd9d0aca6289e85b3980b64cd122ed

Cherry-pick this from nightly to fix the build break while waiting for upstream merge. Once https://github.com/openjdk/jdk11u/pull/62 is merged this should auto-resolve.

