### PR TITLE
Include commitId.txt in archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /build/
 /dist/
 /.idea/
+/.vscode/
+/nbproject/
 nbproject/private/
 /webrev
 /.src-rev
@@ -13,8 +15,8 @@ test/nashorn/lib
 NashornProfile.txt
 **/JTreport/**
 **/JTwork/**
-.gradle/
-corretto-build/
-pre-build/
+/src/utils/LogCompilation/target/
+/.gradle/
+/.project/
+/.settings/
 commitId.txt
-

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -56,7 +56,7 @@ task copySource(type: Copy) {
     into buildRoot
 }
 
-/** 
+/**
  * Scan the patches folder for any .patch that needs
  * to be applied before start building.
  */
@@ -169,6 +169,13 @@ task packageBuildResults(type: Tar) {
         include 'man/man1/**'
         include 'release'
         exclude '**/*.diz'
+    }
+
+    // Copy legal directory specifically to set permission correctly.
+    // See https://github.com/corretto/corretto-11/issues/129
+    from(jdkResultingImage) {
+        include 'legal/**'
+        fileMode 0444
     }
     into "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}"
 }

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -137,6 +137,15 @@ task prepareArtifacts {
                 include "Contents/MacOS/**"
                 exclude "Contents/Home/**/*.diz"
             }
+            from(buildRoot) {
+                include 'ADDITIONAL_LICENSE_INFO'
+                include 'ASSEMBLY_EXCEPTION'
+                include 'LICENSE'
+                include 'README.md'
+                include 'commitId.txt'
+                include 'version.txt'
+                into "Contents/Home"
+            }
             into "${buildDir}/${correttoMacDir}"
         }
         // Set the directory as bundle

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -98,6 +98,7 @@ task packageJdk(type: Zip) {
         exclude '**/*.diz'
     }
     from(buildRoot) {
+        include 'ADDITIONAL_LICENSE_INFO'
         include 'ASSEMBLY_EXCEPTION'
         include 'LICENSE'
         include 'THIRD_PARTY_README'


### PR DESCRIPTION
Cherry-pick missing backport to build logic updates from corretto-jdk