### PR TITLE
Drop duplicate copy of legal files

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -164,7 +164,6 @@ task packageBuildResults(type: Tar) {
         include 'conf/**'
         include 'include/**'
         include 'jmods/**'
-        include 'legal/**'
         include 'lib/**'
         include 'man/man1/**'
         include 'release'


### PR DESCRIPTION
### Notes

While fixing legal file permissions, [code](https://github.com/corretto/corretto-11/blob/0e076f92d1a53550e1c50305b6e81d3082d4fc3d/installers/linux/alpine/tar/build.gradle#L176-L179), we unintentionally copied legal files twice, [1](https://github.com/corretto/corretto-11/blame/develop/installers/linux/alpine/tar/build.gradle#L167), [2](https://github.com/corretto/corretto-11/blame/develop/installers/linux/alpine/tar/build.gradle#L176-L179). Gradle now complains not knowing what to do with duplicate files.

Removing the first copy that has no permission setting in this change.

### How has this been tested?
Can build on alpine

```
/tmp/corretto-11 # ./gradlew :installers:linux:alpine:tar:build \
> -Pcorretto.extra_config=--with-boot-jdk=/tmp/existing_jdk/11/amazon-corretto-11.0.18.10.1-alpine-linux-x64 \
> -Pcorretto.versionOpt=Nightly \
> -Pcorretto.versionDate=2023-04-05

....

BUILD SUCCESSFUL in 12m 16s
```
