### PR TITLE
Dynamic link zlib for non armv7 linux

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -81,7 +81,7 @@ task configureBuild(type: Exec) {
         'bash',
         'configure',
         "--with-version-feature=${version.major}",
-        '--with-zlib=bundled',
+        '--with-zlib=system',
         '--with-stdc++lib=static',
         '--disable-warnings-as-errors'
     ]

--- a/installers/linux/universal/deb/build.gradle
+++ b/installers/linux/universal/deb/build.gradle
@@ -141,6 +141,7 @@ task generateJdkDeb(type: Deb) {
     preUninstall file("$buildRoot/scripts/preun_jdk.sh")
 
     requires('java-common')
+    requires('zlib1g')
     // jdk
     provides('java-compiler')
     provides('java-sdk')

--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -116,6 +116,8 @@ task generateJdkRpm(type: Rpm) {
     preUninstall file("$buildRoot/scripts/preun_java.sh")
     preUninstall file("$buildRoot/scripts/preun_javac.sh")
 
+    requires('zlib')
+
     provides(jdkPackageName, "${epoch}:${version}-${release}", EQUAL)
     provides('java-11-devel', "${epoch}:${version}", EQUAL)
     provides('java-11-openjdk-devel', "${epoch}:${version}", EQUAL)

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -105,11 +105,14 @@ task configureBuild(type: Exec) {
     dependsOn applyPatches
     workingDir "$buildRoot"
 
+    def isArmv7 = project.hasProperty("armv7") ? Boolean.valueOf("${project.getProperty('armv7')}") : false
+    def zlibFlag = isArmv7 ? "--with-zlib=bundled" : "--with-zlib=system" 
+
     // Platform specific flags
     def command = ['bash', 'configure',
-            "--with-cacerts-file=${depsMap[caCerts]}",
-            "--with-zlib=bundled"
+            "--with-cacerts-file=${depsMap[caCerts]}"
     ]
+    command += zlibFlag
     // Common flags
     command += project.correttoCommonFlags
     command += archSpecificFlags


### PR DESCRIPTION
### Notes

Dynamic link zlib for non-armv7 linux. Essentially take https://github.com/corretto/corretto-17/pull/125 but keep `bundled` for armv7

Reason to exclude armv7 for now: build infra is not ready. Builds would fail due to lack of zlib in the system. 

This change is needed for a customer early-try before Q3.
