### PR TITLE
8294281: Allow warnings to be disabled on a per-file basis

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -359,10 +359,15 @@ define SetupCompileNativeFileBody
       endif
     endif
 
+    ifneq ($(DISABLE_WARNING_PREFIX), )
+      $1_WARNINGS_FLAGS := $$(addprefix $(DISABLE_WARNING_PREFIX), \
+        $$($$($1_BASE)_DISABLED_WARNINGS_$(TOOLCHAIN_TYPE)_$$($1_FILENAME)))
+    endif
+
     $1_BASE_CFLAGS :=  $$($$($1_BASE)_CFLAGS) $$($$($1_BASE)_EXTRA_CFLAGS) \
-        $$($$($1_BASE)_SYSROOT_CFLAGS)
+        $$($$($1_BASE)_SYSROOT_CFLAGS) $$($1_WARNINGS_FLAGS)
     $1_BASE_CXXFLAGS := $$($$($1_BASE)_CXXFLAGS) $$($$($1_BASE)_EXTRA_CXXFLAGS) \
-        $$($$($1_BASE)_SYSROOT_CFLAGS) $$($1_EXTRA_CXXFLAGS)
+        $$($$($1_BASE)_SYSROOT_CFLAGS) $$($1_EXTRA_CXXFLAGS) $$($1_WARNINGS_FLAGS)
     $1_BASE_ASFLAGS := $$($$($1_BASE)_ASFLAGS) $$($$($1_BASE)_EXTRA_ASFLAGS)
 
     ifneq ($$(filter %.c, $$($1_FILENAME)), )


### PR DESCRIPTION
Clean backport of https://bugs.openjdk.org/browse/JDK-8294281 to the corretto-11