### PR TITLE
8296812: sprintf is deprecated in Xcode 14

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -169,15 +169,16 @@ void VM_Version::initialize() {
   if (_cpu == CPU_ARM && os::processor_count() == 1 && _model == 0xd07) _features |= CPU_A53MAC;
 
   char buf[512];
-  sprintf(buf, "0x%02x:0x%x:0x%03x:%d", _cpu, _variant, _model, _revision);
-  if (_model2) sprintf(buf+strlen(buf), "(0x%03x)", _model2);
+
+
+  int buf_used_len = os::snprintf_checked(buf, sizeof(buf), "0x%02x:0x%x:0x%03x:%d", _cpu, _variant, _model, _revision);
+  if (_model2) os::snprintf_checked(buf+strlen(buf),sizeof(buf) - buf_used_len, "(0x%03x)", _model2);
   if (_features & CPU_ASIMD) strcat(buf, ", simd");
   if (_features & CPU_CRC32) strcat(buf, ", crc");
   if (_features & CPU_AES)   strcat(buf, ", aes");
   if (_features & CPU_SHA1)  strcat(buf, ", sha1");
   if (_features & CPU_SHA2)  strcat(buf, ", sha256");
   if (_features & CPU_LSE)   strcat(buf, ", lse");
-
   _features_string = os::strdup(buf);
 
   if (FLAG_IS_DEFAULT(UseCRC32)) {

--- a/src/hotspot/os/bsd/attachListener_bsd.cpp
+++ b/src/hotspot/os/bsd/attachListener_bsd.cpp
@@ -248,7 +248,7 @@ int BsdAttachListener::init() {
 //
 BsdAttachOperation* BsdAttachListener::read_request(int s) {
   char ver_str[8];
-  sprintf(ver_str, "%d", ATTACH_PROTOCOL_VER);
+  size_t ver_str_len = os::snprintf_checked(ver_str, sizeof(ver_str), "%d", ATTACH_PROTOCOL_VER);
 
   // The request is a sequence of strings so we first figure out the
   // expected count and the maximum possible length of the request.
@@ -288,11 +288,11 @@ BsdAttachOperation* BsdAttachListener::read_request(int s) {
         // The first string is <ver> so check it now to
         // check for protocol mis-match
         if (str_count == 1) {
-          if ((strlen(buf) != strlen(ver_str)) ||
+          if ((strlen(buf) != ver_str_len) ||
               (atoi(buf) != ATTACH_PROTOCOL_VER)) {
             char msg[32];
-            sprintf(msg, "%d\n", ATTACH_ERROR_BADVERSION);
-            write_fully(s, msg, strlen(msg));
+            int msg_len = os::snprintf_checked(msg, sizeof(msg), "%d\n", ATTACH_ERROR_BADVERSION);
+            write_fully(s, msg, msg_len);
             return NULL;
           }
         }
@@ -415,8 +415,8 @@ void BsdAttachOperation::complete(jint result, bufferedStream* st) {
 
   // write operation result
   char msg[32];
-  sprintf(msg, "%d\n", result);
-  int rc = BsdAttachListener::write_fully(this->socket(), msg, strlen(msg));
+  int msg_len = os::snprintf_checked(msg, sizeof(msg), "%d\n", result);
+  int rc = BsdAttachListener::write_fully(this->socket(), msg, msg_len);
 
   // write any result data
   if (rc == 0) {

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -368,7 +368,7 @@ void os::init_system_properties_values() {
 
 #ifndef __APPLE__
 
-  // Buffer that fits several sprintfs.
+  // Buffer that fits several snprintfs.
   // Note that the space for the colon and the trailing null are provided
   // by the nulls included by the sizeof operator.
   const size_t bufsize =
@@ -422,17 +422,16 @@ void os::init_system_properties_values() {
     const char *v_colon = ":";
     if (v == NULL) { v = ""; v_colon = ""; }
     // That's +1 for the colon and +1 for the trailing '\0'.
-    char *ld_library_path = (char *)NEW_C_HEAP_ARRAY(char,
-                                                     strlen(v) + 1 +
-                                                     sizeof(SYS_EXT_DIR) + sizeof("/lib/") + strlen(cpu_arch) + sizeof(DEFAULT_LIBPATH) + 1,
-                                                     mtInternal);
-    sprintf(ld_library_path, "%s%s" SYS_EXT_DIR "/lib/%s:" DEFAULT_LIBPATH, v, v_colon, cpu_arch);
+    const size_t ld_library_path_size = strlen(v) + 1 + sizeof(SYS_EXT_DIR) +
+            sizeof("/lib/") + strlen(cpu_arch) + sizeof(DEFAULT_LIBPATH) + 1;
+    char *ld_library_path = NEW_C_HEAP_ARRAY(char, ld_library_path_size, mtInternal);
+    os::snprintf_checked(ld_library_path, ld_library_path_size, "%s%s" SYS_EXT_DIR "/lib/%s:" DEFAULT_LIBPATH, v, v_colon, cpu_arch);
     Arguments::set_library_path(ld_library_path);
     FREE_C_HEAP_ARRAY(char, ld_library_path);
   }
 
   // Extensions directories.
-  sprintf(buf, "%s" EXTENSIONS_DIR ":" SYS_EXT_DIR EXTENSIONS_DIR, Arguments::get_java_home());
+  os::snprintf_checked(buf, bufsize, "%s" EXTENSIONS_DIR ":" SYS_EXT_DIR EXTENSIONS_DIR, Arguments::get_java_home());
   Arguments::set_ext_dirs(buf);
 
   FREE_C_HEAP_ARRAY(char, buf);
@@ -447,7 +446,7 @@ void os::init_system_properties_values() {
   size_t system_ext_size = strlen(user_home_dir) + sizeof(SYS_EXTENSIONS_DIR) +
     sizeof(SYS_EXTENSIONS_DIRS);
 
-  // Buffer that fits several sprintfs.
+  // Buffer that fits several snprintfs.
   // Note that the space for the colon and the trailing null are provided
   // by the nulls included by the sizeof operator.
   const size_t bufsize =
@@ -517,11 +516,9 @@ void os::init_system_properties_values() {
     // could cause a change in behavior, but Apple's Java6 behavior
     // can be achieved by putting "." at the beginning of the
     // JAVA_LIBRARY_PATH environment variable.
-    char *ld_library_path = (char *)NEW_C_HEAP_ARRAY(char,
-                                                     strlen(v) + 1 + strlen(l) + 1 +
-                                                     system_ext_size + 3,
-                                                     mtInternal);
-    sprintf(ld_library_path, "%s%s%s%s%s" SYS_EXTENSIONS_DIR ":" SYS_EXTENSIONS_DIRS ":.",
+    const size_t ld_library_path_size = strlen(v) + 1 + strlen(l) + 1 + system_ext_size + 3;
+    char *ld_library_path = NEW_C_HEAP_ARRAY(char, ld_library_path_size, mtInternal);
+    os::snprintf_checked(ld_library_path, ld_library_path_size, "%s%s%s%s%s" SYS_EXTENSIONS_DIR ":" SYS_EXTENSIONS_DIRS ":.",
             v, v_colon, l, l_colon, user_home_dir);
     Arguments::set_library_path(ld_library_path);
     FREE_C_HEAP_ARRAY(char, ld_library_path);
@@ -532,7 +529,7 @@ void os::init_system_properties_values() {
   // Note that the space for the colon and the trailing null are provided
   // by the nulls included by the sizeof operator (so actually one byte more
   // than necessary is allocated).
-  sprintf(buf, "%s" SYS_EXTENSIONS_DIR ":%s" EXTENSIONS_DIR ":" SYS_EXTENSIONS_DIRS,
+  os::snprintf_checked(buf, bufsize, "%s" SYS_EXTENSIONS_DIR ":%s" EXTENSIONS_DIR ":" SYS_EXTENSIONS_DIRS,
           user_home_dir, Arguments::get_java_home());
   Arguments::set_ext_dirs(buf);
 

--- a/src/hotspot/share/adlc/adlc.hpp
+++ b/src/hotspot/share/adlc/adlc.hpp
@@ -108,4 +108,8 @@ typedef unsigned int uintptr_t;
 // it everywhere it needs to be available.
 extern ArchDesc* globalAD;
 
-#endif // SHARE_VM_ADLC_ADLC_HPP
+// Performs snprintf and asserts the result is non-negative (so there was not
+// an encoding error) and that the output was not truncated.
+extern int snprintf_checked(char* buf, size_t len, const char* fmt, ...);
+
+#endif // SHARE_ADLC_ADLC_HPP

--- a/src/hotspot/share/adlc/adlparse.cpp
+++ b/src/hotspot/share/adlc/adlparse.cpp
@@ -210,8 +210,9 @@ void ADLParser::instr_parse(void) {
             return;
           }
           assert(match_rules_cnt < 100," too many match rule clones");
+          const size_t buf_size = strlen(instr->_ident) + 4;
           char* buf = (char*) malloc(strlen(instr->_ident) + 4);
-          sprintf(buf, "%s_%d", instr->_ident, match_rules_cnt++);
+          snprintf_checked(buf, buf_size, "%s_%d", instr->_ident, match_rules_cnt++);
           rule->_result = buf;
           // Check for commutative operations with tree operands.
           matchrule_clone_and_swap(rule, instr->_ident, match_rules_cnt);
@@ -2858,8 +2859,9 @@ void ADLParser::ins_encode_parse_block(InstructForm& inst) {
   // Create a new encoding name based on the name of the instruction
   // definition, which should be unique.
   const char* prefix = "__ins_encode_";
+  const size_t ec_name_size = strlen(inst._ident) + strlen(prefix) + 1;
   char* ec_name = (char*) malloc(strlen(inst._ident) + strlen(prefix) + 1);
-  sprintf(ec_name, "%s%s", prefix, inst._ident);
+  snprintf_checked(ec_name, ec_name_size, "%s%s", prefix, inst._ident);
 
   assert(_AD._encode->encClass(ec_name) == NULL, "shouldn't already exist");
   EncClass* encoding = _AD._encode->add_EncClass(ec_name);
@@ -3329,8 +3331,9 @@ void ADLParser::constant_parse(InstructForm& inst) {
   // Create a new encoding name based on the name of the instruction
   // definition, which should be unique.
   const char* prefix = "__constant_";
+  const size_t ec_name_size = strlen(inst._ident) + strlen(prefix) + 1;
   char* ec_name = (char*) malloc(strlen(inst._ident) + strlen(prefix) + 1);
-  sprintf(ec_name, "%s%s", prefix, inst._ident);
+  snprintf_checked(ec_name, ec_name_size, "%s%s", prefix, inst._ident);
 
   assert(_AD._encode->encClass(ec_name) == NULL, "shouldn't already exist");
   EncClass* encoding = _AD._encode->add_EncClass(ec_name);
@@ -4649,8 +4652,9 @@ char *ADLParser::get_ident_or_literal_constant(const char* description) {
     // Grab a constant expression.
     param = get_paren_expr(description);
     if (param[0] != '(') {
+      const size_t buf_size = strlen(param) + 3;
       char* buf = (char*) malloc(strlen(param) + 3);
-      sprintf(buf, "(%s)", param);
+      snprintf_checked(buf, buf_size, "(%s)", param);
       param = buf;
     }
     assert(is_literal_constant(param),
@@ -5257,8 +5261,9 @@ void ADLParser::next_line() {
 char* ADLParser::get_line_string(int linenum) {
   const char* file = _AD._ADL_file._name;
   int         line = linenum ? linenum : this->linenum();
+  const size_t location_size = strlen(file) + 100;
   char* location = (char *)malloc(strlen(file) + 100);
-  sprintf(location, "\n#line %d \"%s\"\n", line, file);
+  snprintf_checked(location, location_size, "\n#line %d \"%s\"\n", line, file);
   return location;
 }
 

--- a/src/hotspot/share/adlc/archDesc.cpp
+++ b/src/hotspot/share/adlc/archDesc.cpp
@@ -810,7 +810,7 @@ static const char *getRegMask(const char *reg_class_name) {
     const char *mask    = "_mask";
     int         length  = (int)strlen(rc_name) + (int)strlen(mask) + 5;
     char       *regMask = new char[length];
-    sprintf(regMask,"%s%s()", rc_name, mask);
+    snprintf_checked(regMask, length, "%s%s()", rc_name, mask);
     delete[] rc_name;
     return regMask;
   }
@@ -903,7 +903,7 @@ char *ArchDesc::stack_or_reg_mask(OperandForm  &opForm) {
   const char *stack_or = "STACK_OR_";
   int   length         = (int)strlen(stack_or) + (int)strlen(reg_mask_name) + 1;
   char *result         = new char[length];
-  sprintf(result,"%s%s", stack_or, reg_mask_name);
+  snprintf_checked(result, length, "%s%s", stack_or, reg_mask_name);
 
   return result;
 }

--- a/src/hotspot/share/adlc/dfa.cpp
+++ b/src/hotspot/share/adlc/dfa.cpp
@@ -215,13 +215,13 @@ Expr *ArchDesc::calc_cost(FILE *fp, const char *spaces, MatchList &mList, Produc
   Expr *c = new Expr("0");
   if (mList._lchild) { // If left child, add it in
     const char* lchild_to_upper = ArchDesc::getMachOperEnum(mList._lchild);
-    sprintf(Expr::buffer(), "_kids[0]->_cost[%s]", lchild_to_upper);
+    snprintf_checked(Expr::buffer(), STRING_BUFFER_LENGTH, "_kids[0]->_cost[%s]", lchild_to_upper);
     c->add(Expr::buffer());
     delete[] lchild_to_upper;
 }
   if (mList._rchild) { // If right child, add it in
     const char* rchild_to_upper = ArchDesc::getMachOperEnum(mList._rchild);
-    sprintf(Expr::buffer(), "_kids[1]->_cost[%s]", rchild_to_upper);
+    snprintf_checked(Expr::buffer(), STRING_BUFFER_LENGTH, "_kids[1]->_cost[%s]", rchild_to_upper);
     c->add(Expr::buffer());
     delete[] rchild_to_upper;
   }
@@ -751,7 +751,7 @@ const char *Expr::compute_expr(const Expr *c1, const Expr *c2) {
     snprintf(string_buffer, STRING_BUFFER_LENGTH, "%s", c2->_expr);
   }
   else {
-    sprintf( string_buffer, "0");
+    snprintf_checked(string_buffer, STRING_BUFFER_LENGTH, "0");
   }
   string_buffer[STRING_BUFFER_LENGTH - 1] = '\0';
   char *cost = strdup(string_buffer);

--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -25,6 +25,8 @@
 // FORMS.CPP - Definitions for ADL Parser Forms Classes
 #include "adlc.hpp"
 
+#define remaining_buflen(buffer, position) (sizeof(buffer) - ((position) - (buffer)))
+
 //==============================Instructions===================================
 //------------------------------InstructForm-----------------------------------
 InstructForm::InstructForm(const char *id, bool ideal_only)
@@ -1537,7 +1539,7 @@ Predicate *InstructForm::build_predicate() {
         s += strlen(s);
       }
       // Add predicate to working buffer
-      sprintf(s,"/*%s*/(",(char*)i._key);
+      snprintf_checked(s, remaining_buflen(buf, s), "/*%s*/(",(char*)i._key);
       s += strlen(s);
       mnode->build_instr_pred(s,(char*)i._key, 0, path_bitmask, 0);
       s += strlen(s);
@@ -3477,7 +3479,7 @@ void MatchNode::build_internalop( ) {
                        _rChild->_internalop : _rChild->_opType) : "";
   len += (int)strlen(lstr) + (int)strlen(rstr);
   subtree = (char *)malloc(len);
-  sprintf(subtree,"_%s_%s_%s", _opType, lstr, rstr);
+  snprintf_checked(subtree, len, "_%s_%s_%s", _opType, lstr, rstr);
   // Hash the subtree string in _internalOps; if a name exists, use it
   iop = (char *)_AD._internalOps[subtree];
   // Else create a unique name, and add it to the hash table
@@ -3894,8 +3896,9 @@ void MatchRule::matchrule_swap_commutative_op(const char* instr_ident, int count
   MatchRule* clone = new MatchRule(_AD, this);
   // Swap operands of commutative operation
   ((MatchNode*)clone)->swap_commutative_op(true, count);
+  const size_t buf_size = strlen(instr_ident) + 4;
   char* buf = (char*) malloc(strlen(instr_ident) + 4);
-  sprintf(buf, "%s_%d", instr_ident, match_rules_cnt++);
+  snprintf_checked(buf, buf_size, "%s_%d", instr_ident, match_rules_cnt++);
   clone->_result = buf;
 
   clone->_next = this->_next;

--- a/src/hotspot/share/adlc/main.cpp
+++ b/src/hotspot/share/adlc/main.cpp
@@ -457,7 +457,7 @@ static char *base_plus_suffix(const char* base, const char *suffix)
   int len = (int)strlen(base) + (int)strlen(suffix) + 1;
 
   char* fname = new char[len];
-  sprintf(fname,"%s%s",base,suffix);
+  snprintf_checked(fname,len,"%s%s",base,suffix);
   return fname;
 }
 

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -26,6 +26,8 @@
 
 #include "adlc.hpp"
 
+#define remaining_buflen(buffer, position) (sizeof(buffer) - (position - buffer))
+
 // Utilities to characterize effect statements
 static bool is_def(int usedef) {
   switch(usedef) {
@@ -33,6 +35,16 @@ static bool is_def(int usedef) {
   case Component::USE_DEF: return true; break;
   }
   return false;
+}
+
+int snprintf_checked(char* buf, size_t len, const char* fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  int result = vsnprintf(buf, len, fmt, args);
+  va_end(args);
+  assert(result >= 0, "snprintf error");
+  assert(static_cast<size_t>(result) < len, "snprintf truncated");
+  return result;
 }
 
 // Define  an array containing the machine register names, strings.
@@ -197,7 +209,8 @@ static int pipeline_reads_initializer(FILE *fp_cpp, NameList &pipeline_reads, Pi
     return -1;
   }
 
-  char *operand_stages = new char [templen];
+  const size_t operand_stages_size = templen;
+  char *operand_stages = new char [operand_stages_size];
   operand_stages[0] = 0;
   int i = 0;
   templen = 0;
@@ -211,7 +224,7 @@ static int pipeline_reads_initializer(FILE *fp_cpp, NameList &pipeline_reads, Pi
   while ( (paramname = pipeclass->_parameters.iter()) != NULL ) {
     const PipeClassOperandForm *tmppipeopnd =
         (const PipeClassOperandForm *)pipeclass->_localUsage[paramname];
-    templen += sprintf(&operand_stages[templen], "  stage_%s%c\n",
+    templen += snprintf_checked(&operand_stages[templen], operand_stages_size - templen, "  stage_%s%c\n",
       tmppipeopnd ? tmppipeopnd->_stage : "undefined",
       (++i < paramcount ? ',' : ' ') );
   }
@@ -278,6 +291,7 @@ static int pipeline_res_stages_initializer(
   int templen = 1 + commentlen + pipeline->_rescount * (max_stage + 14);
 
   // Allocate space for the resource list
+  const size_t resource_stages_size = templen;
   char * resource_stages = new char [templen];
 
   templen = 0;
@@ -285,7 +299,7 @@ static int pipeline_res_stages_initializer(
     const char * const resname =
       res_stages[i] == 0 ? "undefined" : pipeline->_stages.name(res_stages[i]-1);
 
-    templen += sprintf(&resource_stages[templen], "  stage_%s%-*s // %s\n",
+    templen += snprintf_checked(&resource_stages[templen], resource_stages_size - templen, "  stage_%s%-*s // %s\n",
       resname, max_stage - (int)strlen(resname) + 1,
       (i < pipeline->_rescount-1) ? "," : "",
       pipeline->_reslist.name(i));
@@ -344,7 +358,7 @@ static int pipeline_res_cycles_initializer(
   for (i = 0; i < pipeline->_rescount; i++) {
     if (max_cycles < res_cycles[i])
       max_cycles = res_cycles[i];
-    templen = sprintf(temp, "%d", res_cycles[i]);
+    templen = snprintf_checked(temp, sizeof(temp), "%d", res_cycles[i]);
     if (cyclelen < templen)
       cyclelen = templen;
     commentlen += (int)strlen(pipeline->_reslist.name(i));
@@ -353,12 +367,13 @@ static int pipeline_res_cycles_initializer(
   templen = 1 + commentlen + (cyclelen + 8) * pipeline->_rescount;
 
   // Allocate space for the resource list
-  char * resource_cycles = new char [templen];
+  const size_t resource_cycles_size = templen;
+  char * resource_cycles = new char [resource_cycles_size];
 
   templen = 0;
 
   for (i = 0; i < pipeline->_rescount; i++) {
-    templen += sprintf(&resource_cycles[templen], "  %*d%c // %s\n",
+    templen += snprintf_checked(&resource_cycles[templen], resource_cycles_size - templen, "  %*d%c // %s\n",
       cyclelen, res_cycles[i], (i < pipeline->_rescount-1) ? ',' : ' ', pipeline->_reslist.name(i));
   }
 
@@ -431,7 +446,8 @@ static int pipeline_res_mask_initializer(
      (cyclemasksize * 12) + masklen + (cycledigit * 2) + 30) * element_count;
 
   // Allocate space for the resource list
-  char * resource_mask = new char [templen];
+  const size_t resource_mask_size = templen;
+  char * resource_mask = new char [resource_mask_size];
   char * last_comma = NULL;
 
   templen = 0;
@@ -456,7 +472,7 @@ static int pipeline_res_mask_initializer(
     }
 
     int formatlen =
-      sprintf(&resource_mask[templen], "  %s(0x%0*x, %*d, %*d, %s %s(",
+      snprintf_checked(&resource_mask[templen], resource_mask_size - templen, "  %s(0x%0*x, %*d, %*d, %s %s(",
         pipeline_use_element,
         masklen, used_mask,
         cycledigit, lb, cycledigit, ub,
@@ -496,7 +512,7 @@ static int pipeline_res_mask_initializer(
 
     for (j = cyclemasksize-1; j >= 0; j--) {
       formatlen =
-        sprintf(&resource_mask[templen], "0x%08x%s", res_mask[j], j > 0 ? ", " : "");
+        snprintf_checked(&resource_mask[templen], resource_mask_size - templen, "0x%08x%s", res_mask[j], j > 0 ? ", " : "");
       templen += formatlen;
     }
 
@@ -526,7 +542,7 @@ static int pipeline_res_mask_initializer(
 
     char* args = new char [9 + 2*masklen + maskdigit];
 
-    sprintf(args, "0x%0*x, 0x%0*x, %*d",
+    snprintf_checked(args, 9 + 2*masklen + maskdigit, "0x%0*x, 0x%0*x, %*d",
       masklen, resources_used,
       masklen, resources_used_exclusively,
       maskdigit, element_count);
@@ -1072,9 +1088,9 @@ static void build_instruction_index_mapping( FILE *fp, FormDict &globals, PeepMa
       InstructForm *inst = globals[inst_name]->is_instruction();
       if( inst != NULL ) {
         char inst_prefix[]  = "instXXXX_";
-        sprintf(inst_prefix, "inst%d_",   inst_position);
+        snprintf_checked(inst_prefix, sizeof(inst_prefix), "inst%d_",   inst_position);
         char receiver[]     = "instXXXX->";
-        sprintf(receiver,    "inst%d->", inst_position);
+        snprintf_checked(receiver, sizeof(receiver), "inst%d->", inst_position);
         inst->index_temps( fp, globals, inst_prefix, receiver );
       }
     }
@@ -1170,7 +1186,7 @@ static void check_peepconstraints(FILE *fp, FormDict &globals, PeepMatch *pmatch
         if( left_op_index != 0 ) {
           assert( (left_index <= 9999) && (left_op_index <= 9999), "exceed string size");
           // Must have index into operands
-          sprintf(left_reg_index,",inst%d_idx%d", (int)left_index, left_op_index);
+          snprintf_checked(left_reg_index, sizeof(left_reg_index), ",inst%u_idx%u", (unsigned)left_index, (unsigned)left_op_index);
         } else {
           strcpy(left_reg_index, "");
         }
@@ -1183,7 +1199,7 @@ static void check_peepconstraints(FILE *fp, FormDict &globals, PeepMatch *pmatch
           if( right_op_index != 0 ) {
             assert( (right_index <= 9999) && (right_op_index <= 9999), "exceed string size");
             // Must have index into operands
-            sprintf(right_reg_index,",inst%d_idx%d", (int)right_index, right_op_index);
+            snprintf_checked(right_reg_index, sizeof(right_reg_index), ",inst%u_idx%u", (unsigned)right_index, (unsigned)right_op_index);
           } else {
             strcpy(right_reg_index, "");
           }
@@ -2524,19 +2540,19 @@ void ArchDesc::define_postalloc_expand(FILE *fp, InstructForm &inst) {
     const char* arg_name = ins_encode->rep_var_name(inst, param_no);
     int idx = inst.operand_position_format(arg_name);
     if (strcmp(arg_name, "constanttablebase") == 0) {
-      ib += sprintf(ib, "  unsigned idx_%-5s = mach_constant_base_node_input(); \t// %s, \t%s\n",
+      ib += snprintf_checked(ib, remaining_buflen(idxbuf, ib), "  unsigned idx_%-5s = mach_constant_base_node_input(); \t// %s, \t%s\n",
                     name, type, arg_name);
-      nb += sprintf(nb, "  Node    *n_%-7s = lookup(idx_%s);\n", name, name);
+      nb += snprintf_checked(nb, remaining_buflen(nbuf, nb), "  Node    *n_%-7s = lookup(idx_%s);\n", name, name);
       // There is no operand for the constanttablebase.
     } else if (inst.is_noninput_operand(idx)) {
       globalAD->syntax_err(inst._linenum,
                            "In %s: you can not pass the non-input %s to a postalloc expand encoding.\n",
                            inst._ident, arg_name);
     } else {
-      ib += sprintf(ib, "  unsigned idx_%-5s = idx%d; \t// %s, \t%s\n",
+      ib += snprintf_checked(ib, remaining_buflen(idxbuf, ib), "  unsigned idx_%-5s = idx%d; \t// %s, \t%s\n",
                     name, idx, type, arg_name);
-      nb += sprintf(nb, "  Node    *n_%-7s = lookup(idx_%s);\n", name, name);
-      ob += sprintf(ob, "  %sOper *op_%s = (%sOper *)opnd_array(%d);\n", type, name, type, idx);
+      nb += snprintf_checked(nb, remaining_buflen(nbuf, nb), "  Node    *n_%-7s = lookup(idx_%s);\n", name, name);
+      ob += snprintf_checked(ob, remaining_buflen(opbuf, ob), "  %sOper *op_%s = (%sOper *)opnd_array(%d);\n", type, name, type, idx);
     }
     param_no++;
   }

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -648,7 +648,7 @@ JRT_ENTRY(void, Runtime1::throw_range_check_exception(JavaThread* thread, int in
   const int len = 35;
   assert(len < strlen("Index %d out of bounds for length %d"), "Must allocate more space for message.");
   char message[2 * jintAsStringSize + len];
-  sprintf(message, "Index %d out of bounds for length %d", index, a->length());
+  os::snprintf_checked(message, sizeof(message), "Index %d out of bounds for length %d", index, a->length());
   SharedRuntime::throw_and_post_jvmti_exception(thread, vmSymbols::java_lang_ArrayIndexOutOfBoundsException(), message);
 JRT_END
 
@@ -656,7 +656,7 @@ JRT_END
 JRT_ENTRY(void, Runtime1::throw_index_exception(JavaThread* thread, int index))
   NOT_PRODUCT(_throw_index_exception_count++;)
   char message[16];
-  sprintf(message, "%d", index);
+  os::snprintf_checked(message, sizeof(message), "%d", index);
   SharedRuntime::throw_and_post_jvmti_exception(thread, vmSymbols::java_lang_IndexOutOfBoundsException(), message);
 JRT_END
 

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2190,17 +2190,18 @@ static void print_stack_element_to_stream(outputStream* st, Handle mirror, int m
   }
 
   // Allocate temporary buffer with extra space for formatting and line number
-  char* buf = NEW_RESOURCE_ARRAY(char, buf_len + 64);
+  const size_t buf_size = buf_len + 64;
+  char* buf = NEW_RESOURCE_ARRAY(char, buf_size);
 
   // Print stack trace line in buffer
-  sprintf(buf, "\tat %s.%s(", klass_name, method_name);
+  size_t buf_off = os::snprintf_checked(buf, buf_size, "\tat %s.%s(", klass_name, method_name);
 
   // Print module information
   if (module_name != NULL) {
     if (module_version != NULL) {
-      sprintf(buf + (int)strlen(buf), "%s@%s/", module_name, module_version);
+      buf_off += os::snprintf_checked(buf + buf_off, buf_size - buf_off, "%s@%s/", module_name, module_version);
     } else {
-      sprintf(buf + (int)strlen(buf), "%s/", module_name);
+      buf_off += os::snprintf_checked(buf + buf_off, buf_size - buf_off, "%s/", module_name);
     }
   }
 
@@ -2215,17 +2216,17 @@ static void print_stack_element_to_stream(outputStream* st, Handle mirror, int m
     } else {
       if (source_file_name != NULL && (line_number != -1)) {
         // Sourcename and linenumber
-        sprintf(buf + (int)strlen(buf), "%s:%d)", source_file_name, line_number);
+        buf_off += os::snprintf_checked(buf + buf_off, buf_size - buf_off, "%s:%d)", source_file_name, line_number);
       } else if (source_file_name != NULL) {
         // Just sourcename
-        sprintf(buf + (int)strlen(buf), "%s)", source_file_name);
+        buf_off += os::snprintf_checked(buf + buf_off, buf_size - buf_off, "%s)", source_file_name);
       } else {
         // Neither sourcename nor linenumber
-        sprintf(buf + (int)strlen(buf), "Unknown Source)");
+        buf_off += os::snprintf_checked(buf + buf_off, buf_size - buf_off, "Unknown Source)");
       }
       CompiledMethod* nm = method->code();
       if (WizardMode && nm != NULL) {
-        sprintf(buf + (int)strlen(buf), "(nmethod " INTPTR_FORMAT ")", (intptr_t)nm);
+        os::snprintf_checked(buf + buf_off, buf_size - buf_off, "(nmethod " INTPTR_FORMAT ")", (intptr_t)nm);
       }
     }
   }

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -792,7 +792,8 @@ void Dependencies::write_dependency_to(xmlStream* xtty,
         xtty->object("x", arg.metadata_value());
       }
     } else {
-      char xn[12]; sprintf(xn, "x%d", j);
+      char xn[12];
+      os::snprintf_checked(xn, sizeof(xn), "x%d", j);
       if (arg.is_oop()) {
         xtty->object(xn, Handle(thread, arg.oop_value()));
       } else {

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -876,7 +876,7 @@ void CompileBroker::init_compiler_sweeper_threads() {
     // for JVMCI compiler which can create further ones on demand.
     JVMCI_ONLY(if (!UseJVMCICompiler || !UseDynamicNumberOfCompilerThreads || i == 0) {)
     // Create a name for our thread.
-    sprintf(name_buffer, "%s CompilerThread%d", _compilers[1]->name(), i);
+    os::snprintf_checked(name_buffer, sizeof(name_buffer), "%s CompilerThread%d", _compilers[1]->name(), i);
     Handle thread_oop = create_thread_oop(name_buffer, CHECK);
     thread_handle = JNIHandles::make_global(thread_oop);
     JVMCI_ONLY(})
@@ -897,7 +897,7 @@ void CompileBroker::init_compiler_sweeper_threads() {
 
   for (int i = 0; i < _c1_count; i++) {
     // Create a name for our thread.
-    sprintf(name_buffer, "C1 CompilerThread%d", i);
+    os::snprintf_checked(name_buffer, sizeof(name_buffer), "C1 CompilerThread%d", i);
     Handle thread_oop = create_thread_oop(name_buffer, CHECK);
     jobject thread_handle = JNIHandles::make_global(thread_oop);
     _compiler1_objects[i] = thread_handle;
@@ -956,7 +956,7 @@ void CompileBroker::possibly_add_compiler_threads() {
         // transitions if we bind them to new JavaThreads.
         if (!THREAD->can_call_java()) break;
         char name_buffer[256];
-        sprintf(name_buffer, "%s CompilerThread%d", _compilers[1]->name(), i);
+        os::snprintf_checked(name_buffer, sizeof(name_buffer), "%s CompilerThread%d", _compilers[1]->name(), i);
         Handle thread_oop;
         {
           // We have to give up the lock temporarily for the Java calls.

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -314,9 +314,9 @@ jobjectArray readConfiguration0(JNIEnv *env, TRAPS) {
   for (int i = 0; i < len ; i++) {
     VMStructEntry vmField = JVMCIVMStructs::localHotSpotVMStructs[i];
     instanceHandle vmFieldObj = InstanceKlass::cast(VMField::klass())->allocate_instance_handle(CHECK_NULL);
-    size_t name_buf_len = strlen(vmField.typeName) + strlen(vmField.fieldName) + 2 /* "::" */;
-    char* name_buf = NEW_RESOURCE_ARRAY_IN_THREAD(THREAD, char, name_buf_len + 1);
-    sprintf(name_buf, "%s::%s", vmField.typeName, vmField.fieldName);
+    const size_t name_buf_size = strlen(vmField.typeName) + strlen(vmField.fieldName) + 2 +1 /* "::" */;
+    char* name_buf = NEW_RESOURCE_ARRAY_IN_THREAD(THREAD, char, name_buf_size + 1);
+    os::snprintf(name_buf, name_buf_size, "%s::%s", vmField.typeName, vmField.fieldName);
     CSTRING_TO_JSTRING(name, name_buf);
     CSTRING_TO_JSTRING(type, vmField.typeString);
     VMField::set_name(vmFieldObj, name());

--- a/src/hotspot/share/prims/wbtestmethods/parserTests.cpp
+++ b/src/hotspot/share/prims/wbtestmethods/parserTests.cpp
@@ -174,7 +174,7 @@ WB_ENTRY(jobjectArray, WB_ParseCommandLine(JNIEnv* env, jobject o, jstring j_cmd
     if (arg) {
       arg->value_as_str(buf, sizeof(buf));
     } else {
-      sprintf(buf, "<null>");
+      os::snprintf_checked(buf, sizeof(buf), "<null>");
     }
     oop parsedValue = java_lang_String::create_oop_from_str(buf, CHECK_NULL);
     returnvalue_array_ah->obj_at_put(i*2+1, parsedValue);

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -2253,7 +2253,7 @@ const char* Deoptimization::trap_reason_name(int reason) {
   if ((uint)reason < Reason_LIMIT)
     return _trap_reason_name[reason];
   static char buf[20];
-  sprintf(buf, "reason%d", reason);
+  os::snprintf_checked(buf, sizeof(buf), "reason%d", reason);
   return buf;
 }
 const char* Deoptimization::trap_action_name(int action) {
@@ -2263,7 +2263,7 @@ const char* Deoptimization::trap_action_name(int action) {
   if ((uint)action < Action_LIMIT)
     return _trap_action_name[action];
   static char buf[20];
-  sprintf(buf, "action%d", action);
+  os::snprintf_checked(buf, sizeof(buf), "action%d", action);
   return buf;
 }
 
@@ -2367,7 +2367,7 @@ void Deoptimization::print_statistics() {
             Bytecodes::Code bc = (Bytecodes::Code)(counter & LSB_MASK);
             if (bc_case == BC_CASE_LIMIT && (int)bc == 0)
               bc = Bytecodes::_illegal;
-            sprintf(name, "%s/%s/%s",
+            os::snprintf_checked(name, sizeof(name), "%s/%s/%s",
                     trap_reason_name(reason),
                     trap_action_name(action),
                     Bytecodes::is_defined(bc)? Bytecodes::name(bc): "other");

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -102,6 +102,16 @@ int os::snprintf(char* buf, size_t len, const char* fmt, ...) {
   return result;
 }
 
+int os::snprintf_checked(char* buf, size_t len, const char* fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  int result = os::vsnprintf(buf, len, fmt, args);
+  va_end(args);
+  assert(result >= 0, "os::snprintf error");
+  assert(static_cast<size_t>(result) < len, "os::snprintf truncated");
+  return result;
+}
+
 // Fill in buffer with current local time as an ISO-8601 string.
 // E.g., yyyy-mm-ddThh:mm:ss-zzzz.
 // Returns buffer, or NULL if it failed.
@@ -1311,7 +1321,7 @@ char* os::format_boot_path(const char* format_string,
 FILE* os::fopen(const char* path, const char* mode) {
   char modified_mode[20];
   assert(strlen(mode) + 1 < sizeof(modified_mode), "mode chars plus one extra must fit in buffer");
-  sprintf(modified_mode, "%s" LINUX_ONLY("e") BSD_ONLY("e") WINDOWS_ONLY("N"), mode);
+  os::snprintf_checked(modified_mode, sizeof(modified_mode), "%s" LINUX_ONLY("e") BSD_ONLY("e") WINDOWS_ONLY("N"), mode);
   FILE* file = ::fopen(path, modified_mode);
 
 #if !(defined LINUX || defined BSD || defined _WINDOWS)

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -687,6 +687,10 @@ class os: AllStatic {
   static int vsnprintf(char* buf, size_t len, const char* fmt, va_list args) ATTRIBUTE_PRINTF(3, 0);
   static int snprintf(char* buf, size_t len, const char* fmt, ...) ATTRIBUTE_PRINTF(3, 4);
 
+  // Performs snprintf and asserts the result is non-negative (so there was not
+  // an encoding error) and that the output was not truncated.
+  static int snprintf_checked(char* buf, size_t len, const char* fmt, ...) ATTRIBUTE_PRINTF(3, 4);
+
   // Get host name in buffer provided
   static bool get_host_name(char* buf, size_t buflen);
 

--- a/src/hotspot/share/runtime/perfData.cpp
+++ b/src/hotspot/share/runtime/perfData.cpp
@@ -85,8 +85,9 @@ PerfData::PerfData(CounterNS ns, const char* name, Units u, Variability v)
 
   const char* prefix = PerfDataManager::ns_to_string(ns);
 
-  _name = NEW_C_HEAP_ARRAY(char, strlen(name) + strlen(prefix) + 2, mtInternal);
-  assert(_name != NULL && strlen(name) != 0, "invalid name");
+  const size_t _name_size = strlen(name) + strlen(prefix) + 2;
+  _name = NEW_C_HEAP_ARRAY(char, _name_size, mtInternal);
+  assert(strlen(name) != 0, "invalid name");
 
   if (ns == NULL_NS) {
      // No prefix is added to counters with the NULL_NS namespace.
@@ -101,7 +102,7 @@ PerfData::PerfData(CounterNS ns, const char* name, Units u, Variability v)
      }
   }
   else {
-    sprintf(_name, "%s.%s", prefix, name);
+    os::snprintf_checked(_name, _name_size, "%s.%s", prefix, name);
     // set the F_Supported flag based on the given namespace.
     if (PerfDataManager::is_stable_supported(ns) ||
         PerfDataManager::is_unstable_supported(ns)) {
@@ -366,7 +367,7 @@ char* PerfDataManager::counter_name(const char* ns, const char* name) {
 
    size_t len = strlen(ns) + strlen(name) + 2;
    char* result = NEW_RESOURCE_ARRAY(char, len);
-   sprintf(result, "%s.%s", ns, name);
+   os::snprintf_checked(result, len, "%s.%s", ns, name);
    return result;
 }
 

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -419,7 +419,7 @@ extern "C" JNIEXPORT void disnm(intptr_t p) {
 
 extern "C" JNIEXPORT void printnm(intptr_t p) {
   char buffer[256];
-  sprintf(buffer, "printnm: " INTPTR_FORMAT, p);
+  os::snprintf_checked(buffer, sizeof(buffer), "printnm: " INTPTR_FORMAT, p);
   Command c(buffer);
   CodeBlob* cb = CodeCache::find_blob((address) p);
   if (cb->is_nmethod()) {

--- a/src/hotspot/share/utilities/utf8.cpp
+++ b/src/hotspot/share/utilities/utf8.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "utilities/utf8.hpp"
+#include "runtime/os.hpp"
 
 // Assume the utf8 string is in legal form and has been
 // checked in the class file parser/format checker.
@@ -220,7 +221,7 @@ void UTF8::as_quoted_ascii(const char* utf8_str, int utf8_length, char* buf, int
       *p++ = (char)c;
     } else {
       if (p + 6 >= end) break;      // string is truncated
-      sprintf(p, "\\u%04x", c);
+      os::snprintf_checked(p, 7, "\\u%04x", c);  // counting terminating zero in
       p += 6;
     }
   }
@@ -521,7 +522,7 @@ void UNICODE::as_quoted_ascii(const T* base, int length, char* buf, int buflen) 
       *p++ = (char)c;
     } else {
       if (p + 6 >= end) break;      // string is truncated
-      sprintf(p, "\\u%04x", c);
+      os::snprintf_checked(p, 7, "\\u%04x", c);
       p += 6;
     }
   }

--- a/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_Ports.cpp
+++ b/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_Ports.cpp
@@ -635,7 +635,7 @@ void PORT_GetControls(void* id, INT32 portIndex, PortControlCreator* creator) {
                     if (channelName == NULL) {
                         return;
                     }
-                    sprintf(channelName, "Ch %d", ch);
+                    snprintf(channelName, 16, "Ch %d", ch);
                 }
 
                 void* jControls[2];


### PR DESCRIPTION
### Description
https://developer.apple.com/news/?id=y5mjxqmn

Starting November 1, 2023, the Apple notary service will no longer accept uploads from altool or Xcode 13 or earlier. 


This is not a clean backport and this pull request contains a backport of the closed bug [JDK-8296812](https://bugs.openjdk.org/browse/JDK-8296812) commit [f1522c648c2e](https://github.com/openjdk/jdk/commit/478ef389dc3767edfbe21d10a7f7f1522c648c2e).

The sprintf is deprecated in Xcode 14 and the use of it causing building failure. The build could pass if warnings are disabled for codes that use sprintf method. For the long run, the sprintf could be replaced with snprintf. This patch is trying to check if snprintf could be used.

### How has this been tested?


Successful tier1,tier2,tier3 and jck tests for macos x64/aarch64,generic linux x64 /aarch64, windows x64/x86

