### PR TITLE
Disable build-ids in AL Modular RPMs

### DIFF
--- a/installers/linux/al2/spec/java-11-amazon-corretto-modular.spec.template
+++ b/installers/linux/al2/spec/java-11-amazon-corretto-modular.spec.template
@@ -31,6 +31,9 @@
 %global zlib_option $zlib_option
 %global use_gcc_ver $use_gcc_ver
 
+# Disable build_id links as they can collide between versions of Corretto
+%global _build_id_links none
+
 # The experimental_feature macro gets set to %nil by the template, but that is still defined and
 # the spec doesn't have a quick is not nil check, just define/not defined, this makes it easier to
 # work with


### PR DESCRIPTION
Local build for AL2023 is working as expected. 
Only changing the module RPMs since the others are for AL2 only which don't enable build_ids by default.