### PR TITLE
8315042: NPE in PKCS7.parseOldSignedData

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
@@ -166,6 +166,10 @@ public class PKCS7 {
         contentType = contentInfo.contentType;
         DerValue content = contentInfo.getContent();
 
+        if (content == null) {
+            throw new ParsingException("content is null");
+        }
+
         if (contentType.equals(ContentInfo.SIGNED_DATA_OID)) {
             parseSignedData(content);
         } else if (contentType.equals(ContentInfo.OLD_SIGNED_DATA_OID)) {


### PR DESCRIPTION
Backport-of https://github.com/openjdk/jdk11u-dev/pull/2429 into corretto-11

https://bugs.openjdk.org/browse/JDK-8315042