### PR TITLE
Checkout missing SSLContextDefault from upstream and fix

### DIFF
--- a/test/jdk/sun/security/ssl/SSLContextImpl/SSLContextDefault.java
+++ b/test/jdk/sun/security/ssl/SSLContextImpl/SSLContextDefault.java
@@ -43,7 +43,7 @@ public class SSLContextDefault {
     };
 
     private final static List<String> disabledProtocols = List.<String>of(
-        "SSLv3", "TLSv1", "TLSv1.1"
+        "SSLv3"
     );
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Pulling the test from upstream prior to "8256660: Disable DTLS 1.0" and update to work with TLS1/1.0 enabled

```
$ make run-test TEST="test/jdk/sun/security/ssl/SSLContextImpl/SSLContextDefault.java"
Running test 'jtreg:test/jdk/sun/security/ssl/SSLContextImpl/SSLContextDefault.java'
Passed: sun/security/ssl/SSLContextImpl/SSLContextDefault.java
Test results: passed: 1
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/sun/security/ssl/SSLContextImpl/SSLContextDefault.java
                                                         1     1     0     0   
==============================
TEST SUCCESS
```


