### PR TITLE
Enable DTLS1.0

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
@@ -1344,7 +1344,7 @@ public abstract class SSLContextImpl extends SSLContextSpi {
     }
 
     /*
-     * The SSLContext implementation for customized TLS protocols
+     * The SSLContext implementation for customized DTLS protocols
      *
      * @see SSLContext
      */
@@ -1402,13 +1402,11 @@ public abstract class SSLContextImpl extends SSLContextSpi {
                         ProtocolVersion.DTLS12,
                         ProtocolVersion.DTLS10
                 };
-                if (!client)
-                    return Arrays.asList(candidates);
             } else {
                 // Use the customized TLS protocols.
                 candidates =
                         new ProtocolVersion[customized.size()];
-                candidates = customized.toArray(candidates);
+                candidates = refactored.toArray(candidates);
             }
 
             return getAvailableProtocols(candidates);

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -756,8 +756,8 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
 # Example:
 #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048, \
 #       rsa_pkcs1_sha1, secp224r1
-jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, RC4, DES, MD5withRSA, \
-    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, DTLSv1.0, RC4, DES, \
+    MD5withRSA, DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
     include jdk.disabled.namedCurves
 
 #

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -756,7 +756,7 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
 # Example:
 #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048
 #       rsa_pkcs1_sha1, secp224r1
-jdk.tls.disabledAlgorithms=SSLv3, DTLSv1.0, RC4, DES, \
+jdk.tls.disabledAlgorithms=SSLv3, RC4, DES, \
     MD5withRSA, DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
     include jdk.disabled.namedCurves
 

--- a/test/jdk/javax/net/ssl/DTLS/InvalidRecords.java
+++ b/test/jdk/javax/net/ssl/DTLS/InvalidRecords.java
@@ -38,6 +38,8 @@ import java.net.DatagramPacket;
 import java.net.SocketAddress;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import jdk.test.lib.security.SecurityUtils;
+
 /**
  * Test that if handshake messages are changed, the handshake would fail
  * because of handshaking hash verification.
@@ -46,6 +48,7 @@ public class InvalidRecords extends DTLSOverDatagram {
     private static final AtomicBoolean needInvalidRecords = new AtomicBoolean(true);
 
     public static void main(String[] args) throws Exception {
+        SecurityUtils.removeFromDisabledTlsAlgs("DTLSv1.0");
         InvalidRecords testCase = new InvalidRecords();
         testCase.runTest(testCase);
 

--- a/test/jdk/javax/net/ssl/DTLS/NoMacInitialClientHello.java
+++ b/test/jdk/javax/net/ssl/DTLS/NoMacInitialClientHello.java
@@ -38,6 +38,9 @@
 import java.net.DatagramPacket;
 import java.net.SocketAddress;
 
+import jdk.test.lib.security.SecurityUtils;
+
+
 /**
  * Test that a server is able to discard invalid initial ClientHello silently.
  */
@@ -45,6 +48,7 @@ public class NoMacInitialClientHello extends DTLSOverDatagram {
     boolean needInvalidRecords = true;
 
     public static void main(String[] args) throws Exception {
+        SecurityUtils.removeFromDisabledTlsAlgs("DTLSv1.0");
         System.setProperty("jdk.tls.useExtendedMasterSecret", "false");
         NoMacInitialClientHello testCase = new NoMacInitialClientHello();
         testCase.runTest(testCase);

--- a/test/jdk/sun/security/ssl/SSLContextImpl/SSLContextDefault.java
+++ b/test/jdk/sun/security/ssl/SSLContextImpl/SSLContextDefault.java
@@ -48,11 +48,10 @@ public class SSLContextDefault {
     };
 
     private static final List<String> disabledTlsProtocols = List.<String>of(
-        "SSLv3""
+        "SSLv3"
     );
 
     private static final List<String> disabledDtlsProtocols = List.<String>of(
-        "DTLSv1.0"
     );
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Merging [8256660: Disable DTLS 1.0](https://github.com/corretto/corretto-11/commit/b39a4d24c51c2379ff82d5e46e185a6d2039ad72) and then enabling DTLS so no customers are broken.
```
$ make run-test TEST="test/jdk/sun/security/ssl/SSLContextImpl/SSLContextDefault.java"
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/sun/security/ssl/SSLContextImpl/SSLContextDefault.java
                                                         1     1     0     0   
==============================
TEST SUCCESS
```