### PR TITLE
Add debug level into alpine build

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -40,8 +40,8 @@ ext {
     }
 }
 
-def jdkResultingImage = "$buildRoot/build/linux-${arch}-normal-server-release/images/jdk"
-def testResultingImage = "$buildRoot/build/linux-${arch}-normal-server-release/images/test"
+def jdkResultingImage = "$buildRoot/build/linux-${arch}-normal-server-${correttoDebugLevel}/images/jdk"
+def testResultingImage = "$buildRoot/build/linux-${arch}-normal-server-${correttoDebugLevel}/images/test"
 
 /**
  * Create a local copy of the source tree in our


### PR DESCRIPTION
Similar to https://github.com/corretto/corretto-jdk/commit/20dd34038cb0c01e09dbe514547d5d4e86377396. 

Not a clean backport: 11 naming is a bit different. 

Verified via internal release pipeline, can see fastdebug text:

```
/tmp/alpine/corretto-8/ruiamzn-test # ./amazon-corretto-11.0.25.3.1-alpine-linux-x64/bin/java -version
openjdk version "11.0.25" 2024-10-15 LTS
OpenJDK Runtime Environment Corretto-11.0.25.3.1 (fastdebug build 11.0.25+3-LTS)
OpenJDK 64-Bit Server VM Corretto-11.0.25.3.1 (fastdebug build 11.0.25+3-LTS, mixed mode)
/tmp/alpine/corretto-8/ruiamzn-test # 
```