### PR TITLE
Correct CVE ID in changelog for 11.0.26.4.1 (#391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ The following CVEs are addressed in 11.0.26.4.1:
 
 | CVE            | CVSS | Component                       |
 |----------------|------|---------------------------------|
-| CVE-2024-21502 | 4.8  | hotspot/compiler                |
+| CVE-2025-21502 | 4.8  | hotspot/compiler                |
 
 
 ## Corretto version: 11.0.25.9.1


### PR DESCRIPTION
Resolves #391, see references in that issue and the [OpenJDK 2025-01-21 vulnerability advisories](https://openjdk.org/groups/vulnerability/advisories/2025-01-21)