### PR TITLE
Adding test-image-hotspot-gtest to windows test image

### DIFF
--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -54,7 +54,7 @@ task executeBuild(type: Exec) {
     dependsOn configureBuild
     workingDir "$buildRoot"
 
-    commandLine 'make', 'images', 'test-image-hotspot-jtreg-native', 'test-image-jdk-jtreg-native'
+    commandLine 'make', 'images', 'test-image-hotspot-jtreg-native', 'test-image-jdk-jtreg-native', 'test-image-hotspot-gtest'
 }
 
 task copyImage(type: Copy) {


### PR DESCRIPTION
Adding gtest to make target for executeBuild. This is already present for Linux and mac. These are also already building these (albeit with a distinct, dependent gradle task) for newer JDKs.