### PR TITLE
Backporting Gtest build test-image

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -138,7 +138,7 @@ task importAmazonCacerts(type: Exec) {
 task createTestImage(type: Exec) {
     dependsOn executeBuild
     workingDir "$buildRoot"
-    commandLine 'make','test-image-hotspot-jtreg-native','test-image-jdk-jtreg-native','test-image-hotspot-gtest'
+    commandLine 'make','test-image'
 }
 
 task packageTestImage(type: Tar) {

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -151,7 +151,7 @@ task bundleThirdPartyBinaries {
 task createTestImage(type: Exec) {
     dependsOn executeBuild
     workingDir "$buildRoot"
-    commandLine 'make','test-image-hotspot-jtreg-native','test-image-jdk-jtreg-native','test-image-hotspot-gtest'
+    commandLine 'make','test-image'
 }
 
 task packageTestImage(type: Tar) {

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -85,7 +85,7 @@ task executeBuild(type: Exec) {
 task executeTestBuild(type: Exec) {
     dependsOn executeBuild
     workingDir "$buildRoot"
-    commandLine 'make','test-image-hotspot-jtreg-native','test-image-jdk-jtreg-native','test-image-hotspot-gtest'
+    commandLine 'make','test-image'
 }
 
 task prepareArtifacts {

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -54,7 +54,7 @@ task executeBuild(type: Exec) {
     dependsOn configureBuild
     workingDir "$buildRoot"
 
-    commandLine 'make', 'images', 'test-image-hotspot-jtreg-native', 'test-image-jdk-jtreg-native'
+    commandLine 'make', 'images', 'test-image'
 }
 
 task copyImage(type: Copy) {


### PR DESCRIPTION
Adding in gtest to windows build by backporting fix from 17: https://github.com/corretto/corretto-17/commit/44cbe15e99e48c0b16a7e5e49d4be401c2f3b95b