### PR TITLE
Add test patches from 8202343 and fix 8245545

### DIFF
--- a/test/jdk/javax/net/ssl/TLSv11/GenericBlockCipher.java
+++ b/test/jdk/javax/net/ssl/TLSv11/GenericBlockCipher.java
@@ -27,6 +27,7 @@
  * @test
  * @bug 4873188
  * @summary Support TLS 1.1
+ * @library /test/lib
  * @modules java.security.jgss
  *          java.security.jgss/sun.security.jgss.krb5
  *          java.security.jgss/sun.security.krb5:+open
@@ -49,6 +50,8 @@ import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
+
+import jdk.test.lib.security.SecurityUtils;
 
 public class GenericBlockCipher {
 
@@ -172,7 +175,7 @@ public class GenericBlockCipher {
 
     public static void main(String[] args) throws Exception {
         // Re-enable TLSv1.1 and TLS_RSA_* since test depends on it.
-        SecurityUtils.removeFromDisabledTlsAlgs("TLSv1.1", "TLS_RSA_*");
+        SecurityUtils.removeFromDisabledTlsAlgs("TLS_RSA_*");
 
         String keyFilename =
             System.getProperty("test.src", ".") + "/" + pathToStores +

--- a/test/jdk/javax/net/ssl/sanity/ciphersuites/SystemPropCipherSuitesOrder.java
+++ b/test/jdk/javax/net/ssl/sanity/ciphersuites/SystemPropCipherSuitesOrder.java
@@ -25,11 +25,14 @@ import java.util.stream.Stream;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
 
+import jdk.test.lib.security.SecurityUtils;
+
 /*
  * @test
  * @bug 8234728
  * @library /javax/net/ssl/templates
  *          /javax/net/ssl/TLSCommon
+ *          /test/lib
  * @summary Test TLS ciphersuites order set through System properties
  * @run main/othervm
  *      -Djdk.tls.client.cipherSuites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384

--- a/test/jdk/javax/net/ssl/sanity/ciphersuites/TLSCipherSuitesOrder.java
+++ b/test/jdk/javax/net/ssl/sanity/ciphersuites/TLSCipherSuitesOrder.java
@@ -24,11 +24,14 @@ import java.util.Arrays;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
 
+import jdk.test.lib.security.SecurityUtils;
+
 /*
  * @test
  * @bug 8234728
  * @library /javax/net/ssl/templates
  *          /javax/net/ssl/TLSCommon
+ *          /test/lib
  * @summary Test TLS ciphersuites order.
  *      Parameter order: <protocol> <client cipher order> <server cipher order>
  * @run main/othervm TLSCipherSuitesOrder TLSv13 ORDERED default

--- a/test/jdk/sun/security/ssl/ClientHandshaker/LengthCheckTest.java
+++ b/test/jdk/sun/security/ssl/ClientHandshaker/LengthCheckTest.java
@@ -26,6 +26,7 @@
  * @bug 8044860
  * @summary Vectors and fixed length fields should be verified
  *          for allowed sizes.
+ * @library /test/lib
  * @modules java.base/sun.security.ssl
  * @run main/othervm LengthCheckTest
  * @key randomness
@@ -75,6 +76,8 @@ import java.nio.*;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Iterator;
+
+import jdk.test.lib.security.SecurityUtils;
 
 public class LengthCheckTest {
 
@@ -301,7 +304,7 @@ public class LengthCheckTest {
      */
     public static void main(String args[]) throws Exception {
         // Re-enable TLSv1 and TLS_RSA_* since test depends on it.
-        SecurityUtils.removeFromDisabledTlsAlgs("TLSv1", "TLS_RSA_*");
+        SecurityUtils.removeFromDisabledTlsAlgs("TLS_RSA_*");
 
         List<LengthCheckTest> ccsTests = new ArrayList<>();
 


### PR DESCRIPTION
### Description
The following jtreg tier2 tests are failing due to compilation errors across all platforms:
```
javax/net/ssl/sanity/ciphersuites/SystemPropCipherSuitesOrder.java
javax/net/ssl/sanity/ciphersuites/TLSCipherSuitesOrder.java
javax/net/ssl/TLSv11/GenericBlockCipher.java
sun/security/ssl/ClientHandshaker/LengthCheckTest.java
```
This is due to missing patches from [8202343](https://github.com/corretto/corretto-11/commit/c9c11cbfe8f77573b9487c6a4f126f7cee860270) (which has been reverted) and incorrect merging of [8245545](https://github.com/corretto/corretto-11/commit/463e25fb4c6ae3ba5f4d0ba6616cf92863831cff) i.e. https://github.com/corretto/corretto-11/commit/71a51ac89139129e9f6c3691ba47651e39be7273.

If the original [8245545](https://github.com/corretto/corretto-11/commit/463e25fb4c6ae3ba5f4d0ba6616cf92863831cff) is compared to the manual conflict resolution merge https://github.com/corretto/corretto-11/commit/71a51ac89139129e9f6c3691ba47651e39be7273, `test/jdk/javax/net/ssl/TLSv11/GenericBlockCipher.java` and `test/jdk/sun/security/ssl/ClientHandshaker/LengthCheckTest.java` specifically differ as the conflicts stem from changes from 8202343, and the merge assumes adding the full line changes which is incorrect.

Specifically regarding the compilation error, [8202343](https://github.com/corretto/corretto-11/commit/c9c11cbfe8f77573b9487c6a4f126f7cee860270) adds dependencies i.e. 
```import jdk.test.lib.security.SecurityUtils;```
which [8245545](https://github.com/corretto/corretto-11/commit/463e25fb4c6ae3ba5f4d0ba6616cf92863831cff) depends on. Changes from 8202343 have been partially added to accommodate.

Note: if Corretto 11 ever decides to revert [8245545](https://github.com/corretto/corretto-11/commit/463e25fb4c6ae3ba5f4d0ba6616cf92863831cff), this custom patch should be reverted first as well.

### Related issues
Commits:
- https://github.com/corretto/corretto-11/commit/c9c11cbfe8f77573b9487c6a4f126f7cee860270
- https://github.com/corretto/corretto-11/commit/463e25fb4c6ae3ba5f4d0ba6616cf92863831cff
- https://github.com/corretto/corretto-11/commit/71a51ac89139129e9f6c3691ba47651e39be7273

### Motivation and context
Failing jtreg tier2 tests

### How has this been tested?
Yes, via internal pipelines. Low risk: changes are test code only.

### Platform information
Fixes all Corretto 11 platforms' test failures


### Additional context
n/a
