### PR TITLE
Adding debug symbols

### DIFF
--- a/installers/linux/al2/spec/java-11-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-11-amazon-corretto.spec.template
@@ -199,6 +199,13 @@ Provides: java-11-javadoc = %{epoch}:%{version}-%{release}
 %description javadoc
 Amazon Corretto's packaging of the OpenJDK 11 API documentation.
 
+%package debugsymbols
+Summary: Amazon Corretto 11 zipped debug symbols
+Group: Development
+
+%description debugsymbols
+Amazon Corretto's packaging of the OpenJDK 11 debug symbols.
+
 %prep
 %setup -q -n src -c
 
@@ -230,7 +237,7 @@ bash ./configure \\
         --with-vendor-bug-url="https://github.com/corretto/corretto-11/issues/" \\
         --with-vendor-vm-bug-url="https://github.com/corretto/corretto-11/issues/" \\
         --with-debug-level=$debug_level \\
-        --with-native-debug-symbols=none
+        --with-native-debug-symbols=zipped
 
 make images
 make LOG=debug docs
@@ -358,6 +365,10 @@ fi
 %exclude %{java_lib}/libawt_xawt.so
 %exclude %{java_lib}/libjawt.so
 %exclude %{java_lib}/libsplashscreen.so
+# Exclude debug symbol files
+%exclude %{java_home}/bin/*.diz
+%exclude %{java_lib}/*.diz
+%exclude %{java_lib}/server/*.diz
 
 %exclude %{java_inc}/jawt.h
 %exclude %{java_inc}/linux/jawt_md.h
@@ -369,7 +380,15 @@ fi
 %doc %{java_imgdir}/docs/specs
 %license %{java_imgdir}/docs/legal
 
+%files debugsymbols
+%{java_home}/bin/*.diz
+%{java_home}/lib/*.diz
+%{java_home}/lib/server/*.diz
+
 %changelog
+* Fri Jan 23 2026 Satyen Subramaniam <satyenme@amazon.com>
+- Add package debug symbols
+
 * Thu Aug 18 2022 Dan Lutker <lutkerd@amazon.com>
 - Add ability to set debug_level
 


### PR DESCRIPTION
Adding debug symbols artifact to rpm src. Tested with build process to confirm the debugsymbols artifact is successfully produced.

Adapted from commit for AL2023: https://github.com/corretto/corretto-11/pull/410