### PR TITLE
Fix iso8601_time timezone offset on 32-bit musl (ARM v7)

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -195,6 +195,9 @@ char* os::iso8601_time(char* buffer, size_t buffer_length, bool utc) {
   // Print an ISO 8601 date and time stamp into the buffer
   const int year = 1900 + time_struct.tm_year;
   const int month = 1 + time_struct.tm_mon;
+  // Cast zone_hours and zone_min to int to avoid misalignment in variadic
+  // argument passing on platforms where time_t is wider than int (e.g.,
+  // 32-bit ARM with musl libc which uses 64-bit time_t for Y2038 safety).
   const int printed = jio_snprintf(buffer, buffer_length,
                                    "%04d-%02d-%02dT%02d:%02d:%02d.%03d%c%02d%02d",
                                    year,
@@ -205,8 +208,8 @@ char* os::iso8601_time(char* buffer, size_t buffer_length, bool utc) {
                                    time_struct.tm_sec,
                                    milliseconds_after_second,
                                    sign_local_to_UTC,
-                                   zone_hours,
-                                   zone_min);
+                                   (int)zone_hours,
+                                   (int)zone_min);
   if (printed == 0) {
     assert(false, "Failed jio_printf");
     return NULL;


### PR DESCRIPTION
Fix LogDecorations.iso8601_utctime_test gtest failure on ARM v7 musl where the UTC offset prints as +-136 instead of +0000.

Musl libc uses 64-bit time_t on all architectures (including 32-bit ARM) for Y2038 safety. The zone_hours and zone_min variables are time_t, but jio_snprintf uses %02d which expects a 32-bit int. On 32-bit platforms with 64-bit time_t, this causes variadic argument misalignment — printf consumes 4 bytes where 8 were passed, corrupting subsequent values.

The fix casts zone_hours and zone_min to int before the printf call. These values are always in the range 0–14 and 0–59 respectively, so the narrowing is safe. No behavior change on existing platforms where time_t already matches register width.